### PR TITLE
Migrate GitBook docs to Mintlify-compatible format

### DIFF
--- a/api-reference/README.mdx
+++ b/api-reference/README.mdx
@@ -1,8 +1,7 @@
 ---
+title: "API Reference"
 description: Complete API reference for Publive's Content Delivery and Content Management services
 ---
-
-# API Reference
 
 Publive provides two API services for working with your content:
 
@@ -12,9 +11,7 @@ Publive provides two API services for working with your content:
 
 Read-only APIs for fetching published content. Use the CDS to power your website and applications.
 
-{% content-ref url="content-delivery/README.md" %}
-[Content Delivery API](content-delivery/README.md)
-{% endcontent-ref %}
+<Card title="Content Delivery API" href="/api-reference/content-delivery" />
 
 ## Content Management Service (CMS)
 
@@ -22,13 +19,11 @@ Read-only APIs for fetching published content. Use the CDS to power your website
 
 Full CRUD APIs for creating, updating, and managing content programmatically.
 
-{% content-ref url="content-management/README.md" %}
-[Content Management API](content-management/README.md)
-{% endcontent-ref %}
+<Card title="Content Management API" href="/api-reference/content-management" />
 
 ## Authentication
 
-All API requests require `username` and `password` headers. See [Authentication](../getting-started/authentication.md) for details.
+All API requests require `username` and `password` headers. See [Authentication](/getting-started/authentication) for details.
 
 ## Common Patterns
 
@@ -43,4 +38,4 @@ Both APIs support `page` and `limit` query parameters:
 
 ### Error Handling
 
-All error responses return a descriptive status and message. See [Error Codes](../reference/error-codes.md) for a full reference.
+All error responses return a descriptive status and message. See [Error Codes](/reference/error-codes) for a full reference.

--- a/api-reference/content-delivery/README.mdx
+++ b/api-reference/content-delivery/README.mdx
@@ -1,47 +1,46 @@
 ---
+title: "Content Delivery API"
 description: Read-only APIs for fetching published content from your Publive CMS
 ---
-
-# Content Delivery API
 
 The Content Delivery Service (CDS) provides read-only access to your published content. Use these APIs to power your website, mobile app, or any frontend application.
 
 **Base URL:** `https://cds.thepublive.com/publisher/{publisher_id}/`
 
-{% hint style="info" %}
+<Info>
 All CDS endpoints are **GET** requests. Authentication requires `username` and `password` headers.
-{% endhint %}
+</Info>
 
 ## Site Configuration
 
 | Endpoint | Description |
 | -------- | ----------- |
-| [Publisher Data](publisher-data.md) | Publisher profile, branding, and configuration |
-| [Navbar](navbar.md) | Navigation menu structure |
-| [Footer](footer.md) | Footer configuration and links |
-| [Active Slots](active-slots.md) | Advertisement slot configuration |
-| [Newsletter Groups](newsletter-groups.md) | Newsletter group listings |
-| [Content Types](content-types.md) | Available content types |
+| [Publisher Data](/api-reference/content-delivery/publisher-data) | Publisher profile, branding, and configuration |
+| [Navbar](/api-reference/content-delivery/navbar) | Navigation menu structure |
+| [Footer](/api-reference/content-delivery/footer) | Footer configuration and links |
+| [Active Slots](/api-reference/content-delivery/active-slots) | Advertisement slot configuration |
+| [Newsletter Groups](/api-reference/content-delivery/newsletter-groups) | Newsletter group listings |
+| [Content Types](/api-reference/content-delivery/content-types) | Available content types |
 
 ## Content
 
 | Endpoint | Description |
 | -------- | ----------- |
-| [Category Listing](category-listing.md) | List all categories |
-| [Category Details](category-details.md) | Get a single category by ID or slug |
-| [Tag Listing](tag-listing.md) | List all tags |
-| [Tag Details](tag-details.md) | Get a single tag by ID or slug |
-| [Author Listing](author-listing.md) | List all authors |
-| [Author Details](author-details.md) | Get a single author by ID or slug |
+| [Category Listing](/api-reference/content-delivery/category-listing) | List all categories |
+| [Category Details](/api-reference/content-delivery/category-details) | Get a single category by ID or slug |
+| [Tag Listing](/api-reference/content-delivery/tag-listing) | List all tags |
+| [Tag Details](/api-reference/content-delivery/tag-details) | Get a single tag by ID or slug |
+| [Author Listing](/api-reference/content-delivery/author-listing) | List all authors |
+| [Author Details](/api-reference/content-delivery/author-details) | Get a single author by ID or slug |
 
 ## Posts
 
 | Endpoint | Description |
 | -------- | ----------- |
-| [Post Listing](post-listing.md) | List and filter posts with advanced queries |
-| [Post Details](post-details.md) | Get a single post by ID or slug |
-| [Post Details by URL](post-details-by-url.md) | Get a post by its legacy/relative URL |
-| [Live Blog Updates](live-blog-updates.md) | Get live blog update entries for a post |
+| [Post Listing](/api-reference/content-delivery/post-listing) | List and filter posts with advanced queries |
+| [Post Details](/api-reference/content-delivery/post-details) | Get a single post by ID or slug |
+| [Post Details by URL](/api-reference/content-delivery/post-details-by-url) | Get a post by its legacy/relative URL |
+| [Live Blog Updates](/api-reference/content-delivery/live-blog-updates) | Get live blog update entries for a post |
 
 ## Pagination
 

--- a/api-reference/content-delivery/active-slots.mdx
+++ b/api-reference/content-delivery/active-slots.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Active Slots"
 description: Fetch advertisement slot configuration
 ---
 
-# Active Slots
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/active-slots/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/active-slots/`
 
 Returns the configured advertisement slots for your publication, including slot dimensions, content, and type.
 
@@ -28,8 +27,8 @@ Each slot contains:
 | `formatted_update_on` | string | Last updated timestamp |
 | `type` | string | Slot type: `Image`, `CodeEditor`, or `Editor` |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -53,14 +52,14 @@ Each slot contains:
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/author-details.mdx
+++ b/api-reference/content-delivery/author-details.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Author Details"
 description: Fetch details of a single author by ID or slug
 ---
 
-# Author Details
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/author/{identifier}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/author/{identifier}/`
 
 Returns detailed information about a single author, including their full profile, social links, and SEO metadata.
 
@@ -47,8 +46,8 @@ Returns detailed information about a single author, including their full profile
 | `twitter_image` | string | Twitter Card image URL |
 | `absolute_url` | string | Full public URL path |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -78,14 +77,14 @@ Returns detailed information about a single author, including their full profile
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/author-listing.mdx
+++ b/api-reference/content-delivery/author-listing.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Author Listing"
 description: Fetch a list of all authors
 ---
 
-# Author Listing
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/authors/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/authors/`
 
 Returns a paginated list of all authors with their profile information and social links.
 
@@ -41,8 +40,8 @@ Each author contains:
 | `created_at` | datetime | When the author was created |
 | `updated_at` | datetime | When the author was last updated |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -67,14 +66,14 @@ Each author contains:
   "per_page": 10
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/category-details.mdx
+++ b/api-reference/content-delivery/category-details.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Category Details"
 description: Fetch details of a single category by ID or slug
 ---
 
-# Category Details
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/category/{identifier}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/category/{identifier}/`
 
 Returns detailed information about a single category, including SEO metadata, Open Graph tags, and child categories.
 
@@ -42,8 +41,8 @@ Returns detailed information about a single category, including SEO metadata, Op
 | `twitter_image` | string | Twitter Card image URL |
 | `absolute_url` | string | Full public URL path |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -79,14 +78,14 @@ Returns detailed information about a single category, including SEO metadata, Op
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/category-listing.mdx
+++ b/api-reference/content-delivery/category-listing.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Category Listing"
 description: Fetch a list of all categories
 ---
 
-# Category Listing
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/categories/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/categories/`
 
 Returns a paginated list of all categories with their hierarchical structure.
 
@@ -35,8 +34,8 @@ Each category contains:
 | `category_brand_color` | string/null | Brand color (hex) |
 | `absolute_url` | string | Full public URL path |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -67,14 +66,14 @@ Each category contains:
   "per_page": 10
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/content-types.mdx
+++ b/api-reference/content-delivery/content-types.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Content Types"
 description: Fetch all content types configured for your publication
 ---
 
-# Content Types
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/content-types/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/content-types/`
 
 Returns all content types used on your publication. Content types define the different formats of content available (e.g., Article, Video, Web Story).
 
@@ -27,8 +26,8 @@ Each content type contains:
 | `created_at` | datetime | When the content type was created |
 | `updated_at` | datetime | When the content type was last updated |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -58,14 +57,14 @@ Each content type contains:
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/footer.mdx
+++ b/api-reference/content-delivery/footer.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Footer"
 description: Fetch the footer configuration including links, social media, and branding
 ---
 
-# Footer
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/footer/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/footer/`
 
 Returns the footer configuration including social links, quick menu items, affiliate websites, and branding options.
 
@@ -31,8 +30,8 @@ Returns the footer configuration including social links, quick menu items, affil
 | `latestStories` | boolean | Whether to show latest stories |
 | `addAffiliateWebsites` | array | Affiliate/partner website links |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -63,14 +62,14 @@ Returns the footer configuration including social links, quick menu items, affil
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/live-blog-updates.mdx
+++ b/api-reference/content-delivery/live-blog-updates.mdx
@@ -1,16 +1,15 @@
 ---
+title: "Live Blog Updates"
 description: Fetch live blog update entries for a specific post
 ---
 
-# Live Blog Updates
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/post/{post_id}/live-blog-updates/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/post/{post_id}/live-blog-updates/`
 
 Returns the list of live blog updates for a specific LiveBlog post. Each update contains its own title, content, author, and timestamp.
 
-{% hint style="info" %}
-This endpoint only returns data for posts with `type: "LiveBlog"`. For other post types, use the [Post Details](post-details.md) endpoint.
-{% endhint %}
+<Info>
+This endpoint only returns data for posts with `type: "LiveBlog"`. For other post types, use the [Post Details](/api-reference/content-delivery/post-details) endpoint.
+</Info>
 
 #### Path Parameters
 
@@ -46,8 +45,8 @@ Each live blog update contains:
 | `data.title` | string | Update title/headline |
 | `data.content` | string | Update body (HTML) |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -92,23 +91,23 @@ Each live blog update contains:
   "per_page": 10
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/navbar.mdx
+++ b/api-reference/content-delivery/navbar.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Navbar"
 description: Fetch the navigation menu structure for your website
 ---
 
-# Navbar
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/navbar/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/navbar/`
 
 Returns the navigation menu configuration with hierarchical support for nested menu items.
 
@@ -26,8 +25,8 @@ Each navbar item contains:
 | `children` | array/null | Nested child menu items (same structure) |
 | `open_new_tab` | boolean | Whether to open link in a new tab |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -61,14 +60,14 @@ Each navbar item contains:
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/newsletter-groups.mdx
+++ b/api-reference/content-delivery/newsletter-groups.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Newsletter Groups"
 description: Fetch newsletter group listings
 ---
 
-# Newsletter Groups
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/newsletter-groups/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/newsletter-groups/`
 
 Returns all configured newsletter groups with their metadata.
 
@@ -26,8 +25,8 @@ Each newsletter group contains:
 | `logo_url` | string | Logo image path (relative) |
 | `description` | string | Newsletter group description |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -48,14 +47,14 @@ Each newsletter group contains:
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/post-details-by-url.mdx
+++ b/api-reference/content-delivery/post-details-by-url.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Post Details by URL"
 description: Fetch a post by its legacy or relative URL path
 ---
 
-# Post Details by URL
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/post/?legacy_url={url_path}`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/post/?legacy_url={url_path}`
 
 Returns a single post by matching its legacy or relative URL path. Useful for URL-based routing or migrating from legacy systems.
 
@@ -32,10 +31,10 @@ curl -X GET \
 
 #### Response
 
-Returns the same post object as the [Post Details](post-details.md) endpoint.
+Returns the same post object as the [Post Details](/api-reference/content-delivery/post-details) endpoint.
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -55,23 +54,23 @@ Returns the same post object as the [Post Details](post-details.md) endpoint.
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/post-details.mdx
+++ b/api-reference/content-delivery/post-details.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Post Details"
 description: Fetch details of a single post by ID or slug
 ---
 
-# Post Details
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/post/{identifier}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/post/{identifier}/`
 
 Returns the complete details of a single published post including full content, metadata, categories, tags, and contributors.
 
@@ -23,10 +22,10 @@ Returns the complete details of a single published post including full content, 
 
 #### Response
 
-Returns the same post object structure as the [Post Listing](post-listing.md) endpoint, but for a single post.
+Returns the same post object structure as the [Post Listing](/api-reference/content-delivery/post-listing) endpoint, but for a single post.
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -83,23 +82,23 @@ Returns the same post object structure as the [Post Listing](post-listing.md) en
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/post-listing.mdx
+++ b/api-reference/content-delivery/post-listing.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Post Listing"
 description: Fetch a paginated and filterable list of published posts
 ---
 
-# Post Listing
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/posts/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/posts/`
 
 Returns a paginated list of published posts with support for advanced filtering, sorting, and search. This is the primary endpoint for fetching content on your frontend.
 
@@ -70,9 +69,9 @@ Append operator suffixes to filterable fields to build queries:
 /posts/?type__eq=Article&primary_category.id__eq=100&sort_by=title&sort_order=asc
 ```
 
-{% hint style="info" %}
-**Tip:** This endpoint replaces several deprecated endpoints. Use filters instead of `/posts_by_category/`, `/posts_by_tag/`, `/posts_by_author/`, and `/search/`. See [Deprecated Endpoints](../deprecated/README.md).
-{% endhint %}
+<Info>
+**Tip:** This endpoint replaces several deprecated endpoints. Use filters instead of `/posts_by_category/`, `/posts_by_tag/`, `/posts_by_author/`, and `/search/`. See [Deprecated Endpoints](/api-reference/deprecated).
+</Info>
 
 #### Response Fields
 
@@ -106,8 +105,8 @@ Each post contains:
 | `formatted_first_published_at_datetime` | string | First published timestamp |
 | `formatted_last_published_at_datetime` | string | Last published timestamp |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -163,14 +162,14 @@ Each post contains:
   "per_page": 10
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/publisher-data.mdx
+++ b/api-reference/content-delivery/publisher-data.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Publisher Data"
 description: Fetch publisher profile, branding, and configuration data
 ---
 
-# Publisher Data
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/`
 
 Returns the complete publisher profile including branding, configuration, social links, ad settings, and metadata.
 
@@ -30,8 +29,8 @@ Returns the complete publisher profile including branding, configuration, social
 | `reader_login_config` | object | Reader login/paywall configuration |
 | `ad_configurations` | object | Advertisement configuration settings |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -52,14 +51,14 @@ Returns the complete publisher profile including branding, configuration, social
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/tag-details.mdx
+++ b/api-reference/content-delivery/tag-details.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Tag Details"
 description: Fetch details of a single tag by ID or slug
 ---
 
-# Tag Details
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/tag/{identifier}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/tag/{identifier}/`
 
 Returns detailed information about a single tag, including SEO metadata and social sharing tags.
 
@@ -39,8 +38,8 @@ Returns detailed information about a single tag, including SEO metadata and soci
 | `twitter_image` | string | Twitter Card image URL |
 | `absolute_url` | string | Full public URL path |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -62,14 +61,14 @@ Returns detailed information about a single tag, including SEO metadata and soci
   "message": ""
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-delivery/tag-listing.mdx
+++ b/api-reference/content-delivery/tag-listing.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Tag Listing"
 description: Fetch a list of all tags
 ---
 
-# Tag Listing
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/tags/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/tags/`
 
 Returns a paginated list of all tags.
 
@@ -33,8 +32,8 @@ Each tag contains:
 | `slug` | string | URL-friendly slug |
 | `absolute_url` | string | Full public URL path |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "ok",
@@ -57,14 +56,14 @@ Each tag contains:
   "per_page": 10
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/README.mdx
+++ b/api-reference/content-management/README.mdx
@@ -1,25 +1,24 @@
 ---
+title: "Content Management API"
 description: APIs for creating, updating, and managing content in your Publive CMS
 ---
-
-# Content Management API
 
 The Content Management Service (CMS) provides full CRUD access to your content. Use these APIs to create, update, retrieve, and delete posts, categories, tags, and media programmatically.
 
 **Base URL:** `https://cms.thepublive.com/publisher/{publisher_id}/`
 
-{% hint style="info" %}
+<Info>
 All CMS endpoints require `username` and `password` authentication headers, plus `Content-Type: application/json` for POST and PATCH requests.
-{% endhint %}
+</Info>
 
 ## Resources
 
 | Resource | Endpoints | Description |
 | -------- | --------- | ----------- |
-| [Categories](categories/README.md) | List, Create, Retrieve, Update, Delete | Manage content categories |
-| [Tags](tags/README.md) | List, Create, Retrieve, Update, Delete | Manage content tags |
-| [Posts](posts/README.md) | List, Create, Retrieve, Update, Delete | Manage articles, videos, galleries, and more |
-| [Media Library](media/README.md) | List, Create, Retrieve, Update, Delete | Manage images, videos, and files |
+| [Categories](/api-reference/content-management/categories) | List, Create, Retrieve, Update, Delete | Manage content categories |
+| [Tags](/api-reference/content-management/tags) | List, Create, Retrieve, Update, Delete | Manage content tags |
+| [Posts](/api-reference/content-management/posts) | List, Create, Retrieve, Update, Delete | Manage articles, videos, galleries, and more |
+| [Media Library](/api-reference/content-management/media) | List, Create, Retrieve, Update, Delete | Manage images, videos, and files |
 
 ## Common Patterns
 

--- a/api-reference/content-management/categories/README.mdx
+++ b/api-reference/content-management/categories/README.mdx
@@ -1,8 +1,7 @@
 ---
+title: "Categories"
 description: Manage content categories via the CMS API
 ---
-
-# Categories
 
 Categories provide hierarchical organization for your content. Every post must have a `primary_category` assigned before it can be published.
 
@@ -26,8 +25,8 @@ Categories provide hierarchical organization for your content. Every post must h
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| [GET](list-categories.md) | `/category/` | List all categories |
-| [POST](create-category.md) | `/category/` | Create a new category |
-| [GET](retrieve-category.md) | `/category/{id}/` | Retrieve a category |
-| [PATCH](update-category.md) | `/category/{id}/` | Update a category |
-| [DELETE](delete-category.md) | `/category/{id}/` | Delete a category |
+| [GET](/api-reference/content-management/categories/list-categories) | `/category/` | List all categories |
+| [POST](/api-reference/content-management/categories/create-category) | `/category/` | Create a new category |
+| [GET](/api-reference/content-management/categories/retrieve-category) | `/category/{id}/` | Retrieve a category |
+| [PATCH](/api-reference/content-management/categories/update-category) | `/category/{id}/` | Update a category |
+| [DELETE](/api-reference/content-management/categories/delete-category) | `/category/{id}/` | Delete a category |

--- a/api-reference/content-management/categories/create-category.mdx
+++ b/api-reference/content-management/categories/create-category.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Create Category"
 description: Create a new category
 ---
 
-# Create Category
-
-<mark style="color:green;">`POST`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/category/`
+`POST` `https://cms.thepublive.com/publisher/{publisher_id}/category/`
 
 Creates a new category.
 
@@ -20,8 +19,8 @@ Creates a new category.
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `name`<mark style="color:red;">\*</mark> | string | Yes | Category name |
-| `english_name`<mark style="color:red;">\*</mark> | string | Yes | English name (for permalink generation) |
+| `name`* | string | Yes | Category name |
+| `english_name`* | string | Yes | English name (for permalink generation) |
 | `slug` | string | No | Custom slug (auto-generated if omitted) |
 | `meta_title` | string | No | SEO title |
 | `h1_tag` | string | No | H1 heading tag |
@@ -47,8 +46,8 @@ curl -X POST \
   }'
 ```
 
-{% tabs %}
-{% tab title="201: Created" %}
+<Tabs>
+<Tab title="201: Created">
 ```json
 {
   "status": "success",
@@ -68,18 +67,18 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="400: Bad Request" %}
+<Tab title="400: Bad Request">
 ```json
 {
   "error": {
@@ -88,5 +87,5 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/categories/delete-category.mdx
+++ b/api-reference/content-management/categories/delete-category.mdx
@@ -1,16 +1,15 @@
 ---
+title: "Delete Category"
 description: Delete a category
 ---
 
-# Delete Category
-
-<mark style="color:red;">`DELETE`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
+`DELETE` `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
 
 Permanently deletes a category.
 
-{% hint style="danger" %}
+<Warning>
 **Warning:** This action cannot be undone. Posts assigned to this category will need to be reassigned.
-{% endhint %}
+</Warning>
 
 #### Path Parameters
 
@@ -25,31 +24,31 @@ Permanently deletes a category.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/categories/list-categories.mdx
+++ b/api-reference/content-management/categories/list-categories.mdx
@@ -1,10 +1,9 @@
 ---
+title: "List Categories"
 description: Fetch all categories
 ---
 
-# List Categories
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/category/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/category/`
 
 Returns a paginated list of all categories.
 
@@ -22,8 +21,8 @@ Returns a paginated list of all categories.
 | page | integer | 1 | Page number (max: 1000) |
 | limit | integer | 10 | Items per page (max: 50) |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "count": 477,
@@ -46,14 +45,14 @@ Returns a paginated list of all categories.
   ]
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/categories/retrieve-category.mdx
+++ b/api-reference/content-management/categories/retrieve-category.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Retrieve Category"
 description: Retrieve a single category by ID
 ---
 
-# Retrieve Category
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
 
 Returns the details of a specific category.
 
@@ -21,8 +20,8 @@ Returns the details of a specific category.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "id": 14428,
@@ -38,23 +37,23 @@ Returns the details of a specific category.
   "content_type": null
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/categories/update-category.mdx
+++ b/api-reference/content-management/categories/update-category.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Update Category"
 description: Update an existing category
 ---
 
-# Update Category
-
-<mark style="color:orange;">`PATCH`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
+`PATCH` `https://cms.thepublive.com/publisher/{publisher_id}/category/{id}/`
 
 Updates an existing category. Only send the fields you want to change (partial update).
 
@@ -46,8 +45,8 @@ curl -X PATCH \
   -d '{"name": "Latest News", "meta_title": "Latest News Updates"}'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -67,14 +66,14 @@ curl -X PATCH \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/media/README.mdx
+++ b/api-reference/content-management/media/README.mdx
@@ -1,8 +1,7 @@
 ---
+title: "Media Library"
 description: Manage media assets (images, videos, files) via the CMS API
 ---
-
-# Media Library
 
 The Media Library stores all media assets used across your content. Media items are referenced by ID in post fields like `banner_url`.
 
@@ -25,8 +24,8 @@ The Media Library stores all media assets used across your content. Media items 
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| [GET](list-media.md) | `/media-library/` | List all media |
-| [POST](create-media.md) | `/media-library/` | Upload/create media |
-| [GET](retrieve-media.md) | `/media-library/{id}/` | Retrieve media |
-| [PATCH](update-media.md) | `/media-library/{id}/` | Update media metadata |
-| [DELETE](delete-media.md) | `/media-library/{id}/` | Delete media |
+| [GET](/api-reference/content-management/media/list-media) | `/media-library/` | List all media |
+| [POST](/api-reference/content-management/media/create-media) | `/media-library/` | Upload/create media |
+| [GET](/api-reference/content-management/media/retrieve-media) | `/media-library/{id}/` | Retrieve media |
+| [PATCH](/api-reference/content-management/media/update-media) | `/media-library/{id}/` | Update media metadata |
+| [DELETE](/api-reference/content-management/media/delete-media) | `/media-library/{id}/` | Delete media |

--- a/api-reference/content-management/media/create-media.mdx
+++ b/api-reference/content-management/media/create-media.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Create Media"
 description: Create/upload a media asset
 ---
 
-# Create Media
-
-<mark style="color:green;">`POST`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/media-library/`
+`POST` `https://cms.thepublive.com/publisher/{publisher_id}/media-library/`
 
 Creates a new media entry in the library.
 
@@ -20,8 +19,8 @@ Creates a new media entry in the library.
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `filename`<mark style="color:red;">\*</mark> | string | Yes | Filename |
-| `path`<mark style="color:red;">\*</mark> | string | Yes | Media URL |
+| `filename`* | string | Yes | Filename |
+| `path`* | string | Yes | Media URL |
 | `alt_text` | string | No | Alt text for accessibility |
 | `caption` | string | No | Caption/description |
 | `source` | string | No | Source/credit |
@@ -44,8 +43,8 @@ curl -X POST \
   }'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -64,14 +63,14 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/media/delete-media.mdx
+++ b/api-reference/content-management/media/delete-media.mdx
@@ -1,16 +1,15 @@
 ---
+title: "Delete Media"
 description: Delete a media asset
 ---
 
-# Delete Media
-
-<mark style="color:red;">`DELETE`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
+`DELETE` `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
 
 Permanently deletes a media asset from the library.
 
-{% hint style="danger" %}
+<Warning>
 **Warning:** This action cannot be undone. Posts referencing this media will lose their associated image/file.
-{% endhint %}
+</Warning>
 
 #### Path Parameters
 
@@ -25,22 +24,22 @@ Permanently deletes a media asset from the library.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/media/list-media.mdx
+++ b/api-reference/content-management/media/list-media.mdx
@@ -1,10 +1,9 @@
 ---
+title: "List Media"
 description: Fetch all media assets
 ---
 
-# List Media
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/media-library/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/media-library/`
 
 Returns a paginated list of all media assets in your library.
 
@@ -22,8 +21,8 @@ Returns a paginated list of all media assets in your library.
 | page | integer | 1 | Page number (max: 1000) |
 | limit | integer | 10 | Items per page (max: 50) |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "count": 15420,
@@ -48,14 +47,14 @@ Returns a paginated list of all media assets in your library.
   ]
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/media/retrieve-media.mdx
+++ b/api-reference/content-management/media/retrieve-media.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Retrieve Media"
 description: Retrieve a single media asset by ID
 ---
 
-# Retrieve Media
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
 
 Returns the details of a specific media asset.
 
@@ -21,8 +20,8 @@ Returns the details of a specific media asset.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "id": 999,
@@ -40,14 +39,14 @@ Returns the details of a specific media asset.
   "member": "admin"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/media/update-media.mdx
+++ b/api-reference/content-management/media/update-media.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Update Media"
 description: Update media asset metadata
 ---
 
-# Update Media
-
-<mark style="color:orange;">`PATCH`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
+`PATCH` `https://cms.thepublive.com/publisher/{publisher_id}/media-library/{id}/`
 
 Updates metadata of an existing media asset. Only send the fields you want to change.
 
@@ -43,8 +42,8 @@ curl -X PATCH \
   -d '{"source": "Reuters", "alt_text": "Updated alt text"}'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -61,14 +60,14 @@ curl -X PATCH \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/posts/README.mdx
+++ b/api-reference/content-management/posts/README.mdx
@@ -1,8 +1,7 @@
 ---
+title: "Posts"
 description: Manage posts (articles, videos, galleries, live blogs) via the CMS API
 ---
-
-# Posts
 
 Posts are the primary content entity in Publive. They support multiple content types and publishing workflows.
 
@@ -38,8 +37,8 @@ Posts are the primary content entity in Publive. They support multiple content t
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| [GET](list-posts.md) | `/post/` | List all posts |
-| [POST](create-post.md) | `/post/` | Create a new post |
-| [GET](retrieve-post.md) | `/post/{id}/` | Retrieve a post |
-| [PATCH](update-post.md) | `/post/{id}/` | Update a post |
-| [DELETE](delete-post.md) | `/post/{id}/` | Delete a post |
+| [GET](/api-reference/content-management/posts/list-posts) | `/post/` | List all posts |
+| [POST](/api-reference/content-management/posts/create-post) | `/post/` | Create a new post |
+| [GET](/api-reference/content-management/posts/retrieve-post) | `/post/{id}/` | Retrieve a post |
+| [PATCH](/api-reference/content-management/posts/update-post) | `/post/{id}/` | Update a post |
+| [DELETE](/api-reference/content-management/posts/delete-post) | `/post/{id}/` | Delete a post |

--- a/api-reference/content-management/posts/create-post.mdx
+++ b/api-reference/content-management/posts/create-post.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Create Post"
 description: Create a new post
 ---
 
-# Create Post
-
-<mark style="color:green;">`POST`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/post/`
+`POST` `https://cms.thepublive.com/publisher/{publisher_id}/post/`
 
 Creates a new post. Posts are created with `Draft` status by default.
 
@@ -20,11 +19,11 @@ Creates a new post. Posts are created with `Draft` status by default.
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `title`<mark style="color:red;">\*</mark> | string | Yes | Post headline |
-| `english_title`<mark style="color:red;">\*</mark> | string | Yes | English headline (for slug) |
-| `type`<mark style="color:red;">\*</mark> | string | Yes | `Article`, `Video`, `Web Story`, `Gallery`, `LiveBlog`, `CustomPage`, `BlankPage` |
-| `status`<mark style="color:red;">\*</mark> | string | Yes | `Draft`, `Published`, `Scheduled`, `Approval Pending` |
-| `primary_category`<mark style="color:red;">\*</mark> | integer | Yes | Category ID |
+| `title`* | string | Yes | Post headline |
+| `english_title`* | string | Yes | English headline (for slug) |
+| `type`* | string | Yes | `Article`, `Video`, `Web Story`, `Gallery`, `LiveBlog`, `CustomPage`, `BlankPage` |
+| `status`* | string | Yes | `Draft`, `Published`, `Scheduled`, `Approval Pending` |
+| `primary_category`* | integer | Yes | Category ID |
 | `contributors` | string | No | Comma-separated author IDs |
 | `content` | string | No | HTML body content |
 | `tags` | string | No | Comma-separated tag IDs |
@@ -61,8 +60,8 @@ curl -X POST \
   }'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -98,18 +97,18 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="400: Bad Request" %}
+<Tab title="400: Bad Request">
 ```json
 {
   "error": {
@@ -118,5 +117,5 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/posts/delete-post.mdx
+++ b/api-reference/content-management/posts/delete-post.mdx
@@ -1,16 +1,15 @@
 ---
+title: "Delete Post"
 description: Delete a post
 ---
 
-# Delete Post
-
-<mark style="color:red;">`DELETE`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
+`DELETE` `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
 
 Permanently deletes a post.
 
-{% hint style="danger" %}
+<Warning>
 **Warning:** This action cannot be undone. The post and all its associated data will be permanently removed.
-{% endhint %}
+</Warning>
 
 #### Path Parameters
 
@@ -25,31 +24,31 @@ Permanently deletes a post.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/posts/list-posts.mdx
+++ b/api-reference/content-management/posts/list-posts.mdx
@@ -1,10 +1,9 @@
 ---
+title: "List Posts"
 description: Fetch all posts
 ---
 
-# List Posts
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/post/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/post/`
 
 Returns a paginated list of all posts (including drafts, published, and scheduled).
 
@@ -22,8 +21,8 @@ Returns a paginated list of all posts (including drafts, published, and schedule
 | page | integer | 1 | Page number (max: 1000) |
 | limit | integer | 10 | Items per page (max: 50) |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "count": 33145,
@@ -66,14 +65,14 @@ Returns a paginated list of all posts (including drafts, published, and schedule
   ]
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/posts/retrieve-post.mdx
+++ b/api-reference/content-management/posts/retrieve-post.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Retrieve Post"
 description: Retrieve a single post by ID
 ---
 
-# Retrieve Post
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
 
 Returns the complete details of a specific post.
 
@@ -21,8 +20,8 @@ Returns the complete details of a specific post.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "id": 50123,
@@ -71,23 +70,23 @@ Returns the complete details of a specific post.
   "source": "HeadlessCMS"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="404: Not Found" %}
+<Tab title="404: Not Found">
 ```json
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/posts/update-post.mdx
+++ b/api-reference/content-management/posts/update-post.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Update Post"
 description: Update an existing post
 ---
 
-# Update Post
-
-<mark style="color:orange;">`PATCH`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
+`PATCH` `https://cms.thepublive.com/publisher/{publisher_id}/post/{id}/`
 
 Updates an existing post. Only send the fields you want to change (partial update).
 
@@ -51,8 +50,8 @@ curl -X PATCH \
   -d '{"status": "Published", "title": "Updated Title"}'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -71,14 +70,14 @@ curl -X PATCH \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/tags/README.mdx
+++ b/api-reference/content-management/tags/README.mdx
@@ -1,8 +1,7 @@
 ---
+title: "Tags"
 description: Manage content tags via the CMS API
 ---
-
-# Tags
 
 Tags provide flat, cross-cutting labels for content discovery. Unlike categories, tags have no hierarchy.
 
@@ -23,8 +22,8 @@ Tags provide flat, cross-cutting labels for content discovery. Unlike categories
 
 | Method | Endpoint | Description |
 | ------ | -------- | ----------- |
-| [GET](list-tags.md) | `/tag/` | List all tags |
-| [POST](create-tag.md) | `/tag/` | Create a new tag |
-| [GET](retrieve-tag.md) | `/tag/{id}/` | Retrieve a tag |
-| [PATCH](update-tag.md) | `/tag/{id}/` | Update a tag |
-| [DELETE](delete-tag.md) | `/tag/{id}/` | Delete a tag |
+| [GET](/api-reference/content-management/tags/list-tags) | `/tag/` | List all tags |
+| [POST](/api-reference/content-management/tags/create-tag) | `/tag/` | Create a new tag |
+| [GET](/api-reference/content-management/tags/retrieve-tag) | `/tag/{id}/` | Retrieve a tag |
+| [PATCH](/api-reference/content-management/tags/update-tag) | `/tag/{id}/` | Update a tag |
+| [DELETE](/api-reference/content-management/tags/delete-tag) | `/tag/{id}/` | Delete a tag |

--- a/api-reference/content-management/tags/create-tag.mdx
+++ b/api-reference/content-management/tags/create-tag.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Create Tag"
 description: Create a new tag
 ---
 
-# Create Tag
-
-<mark style="color:green;">`POST`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/tag/`
+`POST` `https://cms.thepublive.com/publisher/{publisher_id}/tag/`
 
 Creates a new tag.
 
@@ -20,8 +19,8 @@ Creates a new tag.
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
-| `name`<mark style="color:red;">\*</mark> | string | Yes | Tag name |
-| `english_name`<mark style="color:red;">\*</mark> | string | Yes | English name |
+| `name`* | string | Yes | Tag name |
+| `english_name`* | string | Yes | English name |
 | `meta_title` | string | No | SEO title |
 | `meta_description` | string | No | SEO description |
 | `content` | string | No | Tag description (HTML) |
@@ -37,8 +36,8 @@ curl -X POST \
   -d '{"name": "AI Technology", "english_name": "AI Technology"}'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -54,14 +53,14 @@ curl -X POST \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/tags/delete-tag.mdx
+++ b/api-reference/content-management/tags/delete-tag.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Delete Tag"
 description: Delete a tag
 ---
 
-# Delete Tag
-
-<mark style="color:red;">`DELETE`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
+`DELETE` `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
 
 Permanently deletes a tag.
 
@@ -21,22 +20,22 @@ Permanently deletes a tag.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/tags/list-tags.mdx
+++ b/api-reference/content-management/tags/list-tags.mdx
@@ -1,10 +1,9 @@
 ---
+title: "List Tags"
 description: Fetch all tags
 ---
 
-# List Tags
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/tag/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/tag/`
 
 Returns a paginated list of all tags.
 
@@ -22,8 +21,8 @@ Returns a paginated list of all tags.
 | page | integer | 1 | Page number (max: 1000) |
 | limit | integer | 10 | Items per page (max: 50) |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "count": 112118,
@@ -42,14 +41,14 @@ Returns a paginated list of all tags.
   ]
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/tags/retrieve-tag.mdx
+++ b/api-reference/content-management/tags/retrieve-tag.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Retrieve Tag"
 description: Retrieve a single tag by ID
 ---
 
-# Retrieve Tag
-
-<mark style="color:blue;">`GET`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
+`GET` `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
 
 Returns the details of a specific tag.
 
@@ -21,8 +20,8 @@ Returns the details of a specific tag.
 | username | string | Yes | API Key |
 | password | string | Yes | API Secret |
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "id": 500,
@@ -34,14 +33,14 @@ Returns the details of a specific tag.
   "meta_description": "Latest breaking news stories"
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/content-management/tags/update-tag.mdx
+++ b/api-reference/content-management/tags/update-tag.mdx
@@ -1,10 +1,9 @@
 ---
+title: "Update Tag"
 description: Update an existing tag
 ---
 
-# Update Tag
-
-<mark style="color:orange;">`PATCH`</mark> `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
+`PATCH` `https://cms.thepublive.com/publisher/{publisher_id}/tag/{id}/`
 
 Updates an existing tag. Only send the fields you want to change (partial update).
 
@@ -42,8 +41,8 @@ curl -X PATCH \
   -d '{"name": "Breaking News Updated"}'
 ```
 
-{% tabs %}
-{% tab title="200: OK" %}
+<Tabs>
+<Tab title="200: OK">
 ```json
 {
   "status": "success",
@@ -59,14 +58,14 @@ curl -X PATCH \
   }
 }
 ```
-{% endtab %}
+</Tab>
 
-{% tab title="401: Unauthorized" %}
+<Tab title="401: Unauthorized">
 ```json
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-{% endtab %}
-{% endtabs %}
+</Tab>
+</Tabs>

--- a/api-reference/deprecated/README.mdx
+++ b/api-reference/deprecated/README.mdx
@@ -1,25 +1,24 @@
 ---
+title: "Deprecated Endpoints"
 description: Deprecated CDS endpoints and their modern replacements
 ---
 
-# Deprecated Endpoints
-
 The following Content Delivery Service endpoints are deprecated. They still function but will be removed in a future version. Use the modern replacements listed below.
 
-{% hint style="warning" %}
-**Migration Required:** All deprecated endpoints should be replaced with the [Post Listing](../content-delivery/post-listing.md) endpoint using query filters.
-{% endhint %}
+<Warning>
+**Migration Required:** All deprecated endpoints should be replaced with the [Post Listing](/api-reference/content-delivery/post-listing) endpoint using query filters.
+</Warning>
 
 ## Migration Guide
 
 | Deprecated Endpoint | Replacement |
 | ------------------- | ----------- |
-| [Posts by Category](posts-by-category.md) `/posts_by_category/{id}/` | `/posts/?categories.id__eq={id}` |
-| [Posts by Tag](posts-by-tag.md) `/posts_by_tag/{id}/` | `/posts/?tags.id__eq={id}` |
-| [Posts by Author](posts-by-author.md) `/posts_by_author/{id}/` | `/posts/?contributors.id__eq={id}` |
-| [Latest Posts](latest-posts.md) `/latest-posts/{type}/` | `/posts/?type__eq={type}` |
-| [Homepage](homepage.md) `/homepage/` | `/posts/` |
-| [Related Posts](related-posts.md) `/related-posts/{id}/` | `/posts/?primary_category.id__eq={category_id}` |
-| [Featured Posts](featured-posts.md) `/featured-posts/` | No direct replacement |
-| [Post by Slug](post-by-slug.md) `/posts_by_slug/{slug}/` | `/post/{slug}/` |
-| [Search Posts](search-posts.md) `/search/` | `/posts/?title__contains={term}` |
+| [Posts by Category](/api-reference/deprecated/posts-by-category) `/posts_by_category/{id}/` | `/posts/?categories.id__eq={id}` |
+| [Posts by Tag](/api-reference/deprecated/posts-by-tag) `/posts_by_tag/{id}/` | `/posts/?tags.id__eq={id}` |
+| [Posts by Author](/api-reference/deprecated/posts-by-author) `/posts_by_author/{id}/` | `/posts/?contributors.id__eq={id}` |
+| [Latest Posts](/api-reference/deprecated/latest-posts) `/latest-posts/{type}/` | `/posts/?type__eq={type}` |
+| [Homepage](/api-reference/deprecated/homepage) `/homepage/` | `/posts/` |
+| [Related Posts](/api-reference/deprecated/related-posts) `/related-posts/{id}/` | `/posts/?primary_category.id__eq={category_id}` |
+| [Featured Posts](/api-reference/deprecated/featured-posts) `/featured-posts/` | No direct replacement |
+| [Post by Slug](/api-reference/deprecated/post-by-slug) `/posts_by_slug/{slug}/` | `/post/{slug}/` |
+| [Search Posts](/api-reference/deprecated/search-posts) `/search/` | `/posts/?title__contains={term}` |

--- a/api-reference/deprecated/featured-posts.mdx
+++ b/api-reference/deprecated/featured-posts.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Featured Posts"
 description: "[DEPRECATED] Fetch featured posts"
 ---
 
-# Featured Posts
+<Warning>
+**Deprecated:** This endpoint has no direct replacement. Use the [Post Listing](/api-reference/content-delivery/post-listing) endpoint with appropriate filters.
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** This endpoint has no direct replacement. Use the [Post Listing](../content-delivery/post-listing.md) endpoint with appropriate filters.
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/featured-posts/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/featured-posts/`
 
 Returns featured/highlighted posts.
 

--- a/api-reference/deprecated/homepage.mdx
+++ b/api-reference/deprecated/homepage.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Homepage"
 description: "[DEPRECATED] Fetch homepage posts"
 ---
 
-# Homepage
+<Warning>
+**Deprecated:** Use `/posts/` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/homepage/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/homepage/`
 
 Returns posts for the homepage.
 

--- a/api-reference/deprecated/latest-posts.mdx
+++ b/api-reference/deprecated/latest-posts.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Latest Posts"
 description: "[DEPRECATED] Fetch latest posts by type"
 ---
 
-# Latest Posts
+<Warning>
+**Deprecated:** Use `/posts/?type__eq={post_type}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?type__eq={post_type}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/latest-posts/{post_type}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/latest-posts/{post_type}/`
 
 Returns the latest posts of a specific type.
 

--- a/api-reference/deprecated/post-by-slug.mdx
+++ b/api-reference/deprecated/post-by-slug.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Post by Slug"
 description: "[DEPRECATED] Fetch a post by slug"
 ---
 
-# Post by Slug
+<Warning>
+**Deprecated:** Use `/post/{slug}/` instead. See [Post Details](/api-reference/content-delivery/post-details).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/post/{slug}/` instead. See [Post Details](../content-delivery/post-details.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_slug/{post_slug}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_slug/{post_slug}/`
 
 Returns a single post by its slug.
 

--- a/api-reference/deprecated/posts-by-author.mdx
+++ b/api-reference/deprecated/posts-by-author.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Posts by Author"
 description: "[DEPRECATED] Fetch posts by author ID"
 ---
 
-# Posts by Author
+<Warning>
+**Deprecated:** Use `/posts/?contributors.id__eq={author_id}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?contributors.id__eq={author_id}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_author/{author_id}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_author/{author_id}/`
 
 Returns posts written by a specific author.
 

--- a/api-reference/deprecated/posts-by-category.mdx
+++ b/api-reference/deprecated/posts-by-category.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Posts by Category"
 description: "[DEPRECATED] Fetch posts by category ID"
 ---
 
-# Posts by Category
+<Warning>
+**Deprecated:** Use `/posts/?categories.id__eq={category_id}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?categories.id__eq={category_id}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_category/{category_id}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_category/{category_id}/`
 
 Returns posts belonging to a specific category.
 

--- a/api-reference/deprecated/posts-by-tag.mdx
+++ b/api-reference/deprecated/posts-by-tag.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Posts by Tag"
 description: "[DEPRECATED] Fetch posts by tag ID"
 ---
 
-# Posts by Tag
+<Warning>
+**Deprecated:** Use `/posts/?tags.id__eq={tag_id}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?tags.id__eq={tag_id}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_tag/{tag_id}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/posts_by_tag/{tag_id}/`
 
 Returns posts tagged with a specific tag.
 

--- a/api-reference/deprecated/related-posts.mdx
+++ b/api-reference/deprecated/related-posts.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Related Posts"
 description: "[DEPRECATED] Fetch related posts"
 ---
 
-# Related Posts
+<Warning>
+**Deprecated:** Use `/posts/?primary_category.id__eq={category_id}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?primary_category.id__eq={category_id}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/related-posts/{post_id}/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/related-posts/{post_id}/`
 
 Returns posts related to a specific post (based on category).
 

--- a/api-reference/deprecated/search-posts.mdx
+++ b/api-reference/deprecated/search-posts.mdx
@@ -1,14 +1,13 @@
 ---
+title: "Search Posts"
 description: "[DEPRECATED] Search posts"
 ---
 
-# Search Posts
+<Warning>
+**Deprecated:** Use `/posts/?title__contains={search_term}` instead. See [Post Listing](/api-reference/content-delivery/post-listing).
+</Warning>
 
-{% hint style="warning" %}
-**Deprecated:** Use `/posts/?title__contains={search_term}` instead. See [Post Listing](../content-delivery/post-listing.md).
-{% endhint %}
-
-<mark style="color:blue;">`GET`</mark> `https://cds.thepublive.com/publisher/{publisher_id}/search/`
+`GET` `https://cds.thepublive.com/publisher/{publisher_id}/search/`
 
 Searches posts by keyword.
 

--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "Mint Starter Kit",
+  "name": "Publive API Docs",
   "colors": {
     "primary": "#16A34A",
     "light": "#07C983",
@@ -48,21 +48,114 @@
         ]
       },
       {
-        "tab": "API reference",
+        "tab": "API Reference",
         "groups": [
           {
-            "group": "API documentation",
+            "group": "Overview",
             "pages": [
-              "api-reference/introduction"
+              "api-reference/README"
             ]
           },
           {
-            "group": "Endpoint examples",
+            "group": "Content Delivery API",
             "pages": [
-              "api-reference/endpoint/get",
-              "api-reference/endpoint/create",
-              "api-reference/endpoint/delete",
-              "api-reference/endpoint/webhook"
+              "api-reference/content-delivery/README",
+              {
+                "group": "Site Configuration",
+                "pages": [
+                  "api-reference/content-delivery/publisher-data",
+                  "api-reference/content-delivery/navbar",
+                  "api-reference/content-delivery/footer",
+                  "api-reference/content-delivery/active-slots",
+                  "api-reference/content-delivery/newsletter-groups",
+                  "api-reference/content-delivery/content-types"
+                ]
+              },
+              {
+                "group": "Content",
+                "pages": [
+                  "api-reference/content-delivery/category-listing",
+                  "api-reference/content-delivery/category-details",
+                  "api-reference/content-delivery/tag-listing",
+                  "api-reference/content-delivery/tag-details",
+                  "api-reference/content-delivery/author-listing",
+                  "api-reference/content-delivery/author-details"
+                ]
+              },
+              {
+                "group": "Posts",
+                "pages": [
+                  "api-reference/content-delivery/post-listing",
+                  "api-reference/content-delivery/post-details",
+                  "api-reference/content-delivery/post-details-by-url",
+                  "api-reference/content-delivery/live-blog-updates"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Content Management API",
+            "pages": [
+              "api-reference/content-management/README",
+              {
+                "group": "Categories",
+                "pages": [
+                  "api-reference/content-management/categories/README",
+                  "api-reference/content-management/categories/list-categories",
+                  "api-reference/content-management/categories/create-category",
+                  "api-reference/content-management/categories/retrieve-category",
+                  "api-reference/content-management/categories/update-category",
+                  "api-reference/content-management/categories/delete-category"
+                ]
+              },
+              {
+                "group": "Tags",
+                "pages": [
+                  "api-reference/content-management/tags/README",
+                  "api-reference/content-management/tags/list-tags",
+                  "api-reference/content-management/tags/create-tag",
+                  "api-reference/content-management/tags/retrieve-tag",
+                  "api-reference/content-management/tags/update-tag",
+                  "api-reference/content-management/tags/delete-tag"
+                ]
+              },
+              {
+                "group": "Posts",
+                "pages": [
+                  "api-reference/content-management/posts/README",
+                  "api-reference/content-management/posts/list-posts",
+                  "api-reference/content-management/posts/create-post",
+                  "api-reference/content-management/posts/retrieve-post",
+                  "api-reference/content-management/posts/update-post",
+                  "api-reference/content-management/posts/delete-post"
+                ]
+              },
+              {
+                "group": "Media Library",
+                "pages": [
+                  "api-reference/content-management/media/README",
+                  "api-reference/content-management/media/list-media",
+                  "api-reference/content-management/media/create-media",
+                  "api-reference/content-management/media/retrieve-media",
+                  "api-reference/content-management/media/update-media",
+                  "api-reference/content-management/media/delete-media"
+                ]
+              }
+            ]
+          },
+          {
+            "group": "Deprecated",
+            "pages": [
+              "api-reference/deprecated/README",
+              "api-reference/deprecated/posts-by-category",
+              "api-reference/deprecated/posts-by-tag",
+              "api-reference/deprecated/posts-by-author",
+              "api-reference/deprecated/latest-posts",
+              "api-reference/deprecated/homepage",
+              "api-reference/deprecated/related-posts",
+              "api-reference/deprecated/featured-posts",
+              "api-reference/deprecated/post-by-slug",
+              "api-reference/deprecated/search-posts"
             ]
           }
         ]
@@ -102,15 +195,15 @@
   },
   "contextual": {
     "options": [
-     "copy",
-     "view",
-     "chatgpt",
-     "claude",
-     "perplexity",
-     "mcp",
-     "cursor",
-     "vscode"
-   ]
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity",
+      "mcp",
+      "cursor",
+      "vscode"
+    ]
   },
   "footer": {
     "socials": {


### PR DESCRIPTION
Convert all 53 API reference files from GitBook syntax to Mintlify components:
- Replace {% hint %} blocks with <Info>, <Warning> components
- Replace {% tabs %}/{% tab %} with <Tabs>/<Tab> components
- Replace {% content-ref %} with <Card> components
- Remove <mark> HTML tags, use clean inline code formatting
- Add frontmatter `title` fields (Mintlify requirement)
- Remove duplicate # headings (Mintlify uses frontmatter title)
- Convert internal .md links to Mintlify absolute paths

Update docs.json navigation to include all API reference sections:
- Content Delivery API (site config, content, posts)
- Content Management API (categories, tags, posts, media)
- Deprecated endpoints

https://claude.ai/code/session_01HNYnubGoK9nQ2rf1cfGDfv