### PR TITLE
Replace default Mintlify index.mdx with Publive landing page

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -1,97 +1,107 @@
 ---
-title: "Introduction"
-description: "Welcome to the new home for your documentation"
+title: "Publive Documentation"
+description: "India-first headless CMS for modern digital publishers and enterprises"
 ---
 
-## Setting up
+## Welcome to Publive
 
-Get your documentation site up and running in minutes.
+Publive is an India-first headless CMS built for modern digital publishers and enterprises. Manage content through powerful APIs and build any frontend experience with your preferred framework.
 
-<Card
-  title="Start here"
-  icon="rocket"
-  href="/quickstart"
-  horizontal
->
-  Follow our three step quickstart guide.
-</Card>
-
-## Make it yours
-
-Design a docs site that looks great and empowers your users.
-
-<Columns cols={2}>
+<CardGroup cols={2}>
   <Card
-    title="Edit locally"
-    icon="pen-to-square"
-    href="/development"
+    title="Introduction"
+    icon="book-open"
+    href="/documentation/getting-started/introduction"
   >
-    Edit your docs locally and preview them in real time.
+    What is Publive and how it works
   </Card>
   <Card
-    title="Customize your site"
-    icon="palette"
-    href="/essentials/settings"
+    title="Quick Start"
+    icon="rocket"
+    href="/documentation/getting-started/quick-start"
   >
-    Customize the design and colors of your site to match your brand.
-  </Card>
-    <Card
-    title="Set up navigation"
-    icon="map"
-    href="/essentials/navigation"
-  >
-    Organize your docs to help users find what they need and succeed with your product.
+    Your first API call in 5 minutes
   </Card>
   <Card
-    title="API documentation"
+    title="Core Concepts"
+    icon="cube"
+    href="/documentation/getting-started/core-concepts"
+  >
+    Posts, categories, tags, authors, and media
+  </Card>
+  <Card
+    title="Authentication"
+    icon="key"
+    href="/documentation/getting-started/authentication"
+  >
+    API keys and credential setup
+  </Card>
+</CardGroup>
+
+## Why Publive?
+
+<CardGroup cols={3}>
+  <Card title="Headless Architecture" icon="layer-group">
+    Decouple content from presentation. Use any frontend — React, Next.js, Angular, Vue, or native apps.
+  </Card>
+  <Card title="Multi-Format Content" icon="photo-film">
+    Articles, Videos, Web Stories, Galleries, Live Blogs, Custom Pages — all from one platform.
+  </Card>
+  <Card title="Enterprise Governance" icon="shield-check">
+    Maker-checker workflows, multi-step approvals, and full audit trails for regulated industries.
+  </Card>
+  <Card title="AI-Powered Features" icon="wand-magic-sparkles">
+    Auto-tagging, plagiarism detection, SEO scoring, and content recommendations built in.
+  </Card>
+  <Card title="India-First" icon="globe">
+    Built for Indian publishers with native support for Hindi, Tamil, Bengali, and more.
+  </Card>
+  <Card title="Developer Friendly" icon="code">
+    Clean REST APIs, intuitive query operators, and comprehensive documentation to ship fast.
+  </Card>
+</CardGroup>
+
+## Explore Guides
+
+<CardGroup cols={3}>
+  <Card
+    title="Frontend Integration"
+    icon="browser"
+    href="/documentation/guides/frontend-integration"
+  >
+    Build with React, Next.js, Angular, or Vue
+  </Card>
+  <Card
+    title="Workflows"
+    icon="diagram-project"
+    href="/documentation/guides/workflows"
+  >
+    Approval flows, maker-checker, and state management
+  </Card>
+  <Card
+    title="Industry-Specific"
+    icon="building"
+    href="/documentation/guides/industry-specific"
+  >
+    Guides for Media, BFSI, and Pharma
+  </Card>
+</CardGroup>
+
+## Integrations & Reference
+
+<CardGroup cols={2}>
+  <Card
+    title="Webhooks & Integrations"
+    icon="plug"
+    href="/documentation/webhooks-integrations"
+  >
+    Webhooks, AI features, and third-party service integrations
+  </Card>
+  <Card
+    title="API Reference"
     icon="terminal"
-    href="/api-reference/introduction"
+    href="/documentation/reference"
   >
-    Auto-generate API documentation from OpenAPI specifications.
+    Rate limits, error codes, changelog, and migration guides
   </Card>
-</Columns>
-
-## Create beautiful pages
-
-Everything you need to create world-class documentation.
-
-<Columns cols={2}>
-  <Card
-    title="Write with MDX"
-    icon="pen-fancy"
-    href="/essentials/markdown"
-  >
-    Use MDX to style your docs pages.
-  </Card>
-  <Card
-    title="Code samples"
-    icon="code"
-    href="/essentials/code"
-  >
-    Add sample code to demonstrate how to use your product.
-  </Card>
-  <Card
-    title="Images"
-    icon="image"
-    href="/essentials/images"
-  >
-    Display images and other media.
-  </Card>
-  <Card
-    title="Reusable snippets"
-    icon="recycle"
-    href="/essentials/reusable-snippets"
-  >
-    Write once and reuse across your docs.
-  </Card>
-</Columns>
-
-## Need inspiration?
-
-<Card
-  title="See complete examples"
-  icon="stars"
-  href="https://mintlify.com/customers"
->
-  Browse our showcase of exceptional documentation sites.
-</Card>
+</CardGroup>


### PR DESCRIPTION
Add a proper documentation landing page with:
- Hero section with Publive value proposition
- Getting Started card grid (Introduction, Quick Start, Core Concepts, Auth)
- Why Publive section highlighting 6 key capabilities
- Explore Guides section linking to Frontend, Workflows, Industry guides
- Integrations & Reference section

https://claude.ai/code/session_01HNYnubGoK9nQ2rf1cfGDfv