### PR TITLE
Replace custom response tabs with Mintlify ResponseExample components

### DIFF
--- a/api-reference/content-delivery/active-slots.mdx
+++ b/api-reference/content-delivery/active-slots.mdx
@@ -18,22 +18,9 @@ Returns the configured advertisement slots for your publication, including slot 
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each slot contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique slot identifier |
-| `name` | string | Slot name |
-| `data` | object | Slot configuration (size, HTML content, `contains_ads` flag) |
-| `registered_slot` | object | Registered slot metadata |
-| `formatted_update_on` | string | Last updated timestamp |
-| `type` | string | Slot type: `Image`, `CodeEditor`, or `Editor` |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -56,14 +43,12 @@ Each slot contains:
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/author-details.mdx
+++ b/api-reference/content-delivery/author-details.mdx
@@ -22,35 +22,9 @@ Returns detailed information about a single author, including their full profile
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique author identifier |
-| `name` | string | Author name |
-| `slug` | string | URL-friendly slug |
-| `email` | string | Author email |
-| `description` | string | Author bio |
-| `linkedin` | string | LinkedIn profile URL |
-| `twitter` | string | Twitter profile URL |
-| `instagram` | string | Instagram profile URL |
-| `facebook` | string | Facebook profile URL |
-| `avatar` | string/null | Profile image URL |
-| `created_at` | datetime | When the author was created |
-| `updated_at` | datetime | When the author was last updated |
-| `meta_title` | string | SEO meta title |
-| `meta_description` | string | SEO meta description |
-| `og_title` | string | Open Graph title |
-| `og_description` | string | Open Graph description |
-| `og_image` | string | Open Graph image URL |
-| `twitter_title` | string | Twitter Card title |
-| `twitter_description` | string | Twitter Card description |
-| `twitter_image` | string | Twitter Card image URL |
-| `absolute_url` | string | Full public URL path |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -79,14 +53,12 @@ Returns detailed information about a single author, including their full profile
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/author-listing.mdx
+++ b/api-reference/content-delivery/author-listing.mdx
@@ -26,28 +26,9 @@ Returns a paginated list of all authors with their profile information and socia
   Items per page (max: 50)
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each author contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique author identifier |
-| `name` | string | Author name |
-| `slug` | string | URL-friendly slug |
-| `email` | string | Author email |
-| `description` | string | Author bio |
-| `linkedin` | string | LinkedIn profile URL |
-| `twitter` | string | Twitter profile URL |
-| `instagram` | string | Instagram profile URL |
-| `facebook` | string | Facebook profile URL |
-| `avatar` | string/null | Profile image URL |
-| `created_at` | datetime | When the author was created |
-| `updated_at` | datetime | When the author was last updated |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -71,14 +52,12 @@ Each author contains:
   "per_page": 10
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/category-details.mdx
+++ b/api-reference/content-delivery/category-details.mdx
@@ -22,30 +22,9 @@ Returns detailed information about a single category, including SEO metadata, Op
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique category identifier |
-| `name` | string | Category name |
-| `slug` | string | URL-friendly slug |
-| `content` | string | Category description (HTML) |
-| `category_brand_color` | string/null | Brand color (hex) |
-| `child_categories` | array | List of child category objects |
-| `parent_category` | object/null | Parent category details |
-| `meta_title` | string | SEO meta title |
-| `meta_description` | string | SEO meta description |
-| `og_title` | string | Open Graph title |
-| `og_description` | string | Open Graph description |
-| `og_image` | string | Open Graph image URL |
-| `twitter_title` | string | Twitter Card title |
-| `twitter_description` | string | Twitter Card description |
-| `twitter_image` | string | Twitter Card image URL |
-| `absolute_url` | string | Full public URL path |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -80,14 +59,12 @@ Returns detailed information about a single category, including SEO metadata, Op
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/category-listing.mdx
+++ b/api-reference/content-delivery/category-listing.mdx
@@ -26,22 +26,9 @@ Returns a paginated list of all categories with their hierarchical structure.
   Items per page (max: 50)
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each category contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique category identifier |
-| `name` | string | Category name |
-| `slug` | string | URL-friendly slug |
-| `parent_category` | object/null | Parent category details (if nested) |
-| `category_brand_color` | string/null | Brand color (hex) |
-| `absolute_url` | string | Full public URL path |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -71,14 +58,12 @@ Each category contains:
   "per_page": 10
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/content-types.mdx
+++ b/api-reference/content-delivery/content-types.mdx
@@ -18,21 +18,9 @@ Returns all content types used on your publication. Content types define the dif
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each content type contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Content type display name |
-| `api_slug` | string | API-friendly slug for single item queries |
-| `api_collections_slug` | string | API-friendly slug for collection queries |
-| `created_at` | datetime | When the content type was created |
-| `updated_at` | datetime | When the content type was last updated |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -61,14 +49,12 @@ Each content type contains:
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/footer.mdx
+++ b/api-reference/content-delivery/footer.mdx
@@ -18,25 +18,9 @@ Returns the footer configuration including social links, quick menu items, affil
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `logo` | string/null | Footer logo URL |
-| `app_links` | object | App download links (iOS, Android, Web) |
-| `short_bio` | string | Short publisher description |
-| `textColor` | string | Footer text color (hex) |
-| `accentColor` | string | Footer accent color (hex) |
-| `newsletter` | boolean | Whether newsletter signup is enabled |
-| `socialLinks` | array | Social media links |
-| `addQuickMenu` | array | Quick navigation links |
-| `copyRightText` | string | Copyright notice text |
-| `latestStories` | boolean | Whether to show latest stories |
-| `addAffiliateWebsites` | array | Affiliate/partner website links |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -66,14 +50,12 @@ Returns the footer configuration including social links, quick menu items, affil
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/live-blog-updates.mdx
+++ b/api-reference/content-delivery/live-blog-updates.mdx
@@ -34,23 +34,9 @@ This endpoint only returns data for posts with `type: "LiveBlog"`. For other pos
   Items per page (max: 50)
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each live blog update contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique update identifier |
-| `author` | object | Author details (`id`, `name`, `slug`, `description`, social links, `avatar`) |
-| `created_at` | datetime | When the update was created |
-| `updated_at` | datetime | When the update was last modified |
-| `is_pinned` | boolean | Whether this update is pinned to the top |
-| `data.title` | string | Update title/headline |
-| `data.content` | string | Update body (HTML) |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -94,23 +80,19 @@ Each live blog update contains:
   "per_page": 10
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/navbar.mdx
+++ b/api-reference/content-delivery/navbar.mdx
@@ -18,20 +18,9 @@ Returns the navigation menu configuration with hierarchical support for nested m
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each navbar item contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `link` | string | URL path for the menu item |
-| `name` | string | Display text |
-| `children` | array/null | Nested child menu items (same structure) |
-| `open_new_tab` | boolean | Whether to open link in a new tab |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -64,14 +53,12 @@ Each navbar item contains:
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/newsletter-groups.mdx
+++ b/api-reference/content-delivery/newsletter-groups.mdx
@@ -18,20 +18,9 @@ Returns all configured newsletter groups with their metadata.
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each newsletter group contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique newsletter group identifier |
-| `name` | string | Newsletter group name |
-| `logo_url` | string | Logo image path (relative) |
-| `description` | string | Newsletter group description |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -51,14 +40,12 @@ Each newsletter group contains:
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/post-details-by-url.mdx
+++ b/api-reference/content-delivery/post-details-by-url.mdx
@@ -31,13 +31,11 @@ curl -X GET \
   -H 'password: YOUR_API_SECRET'
 ```
 
-#### Response
-
 Returns the same post object as the [Post Details](/api-reference/content-delivery/post-details) endpoint.
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "ok",
   "data": {
@@ -56,23 +54,19 @@ Returns the same post object as the [Post Details](/api-reference/content-delive
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/post-details.mdx
+++ b/api-reference/content-delivery/post-details.mdx
@@ -22,13 +22,9 @@ Returns the complete details of a single published post including full content, 
   API Secret
 </ParamField>
 
-#### Response
+<ResponseExample>
 
-Returns the same post object structure as the [Post Listing](/api-reference/content-delivery/post-listing) endpoint, but for a single post.
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -84,23 +80,19 @@ Returns the same post object structure as the [Post Listing](/api-reference/cont
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Post not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/post-listing.mdx
+++ b/api-reference/content-delivery/post-listing.mdx
@@ -84,41 +84,9 @@ Append operator suffixes to filterable fields to build queries:
 **Tip:** This endpoint replaces several deprecated endpoints. Use filters instead of `/posts_by_category/`, `/posts_by_tag/`, `/posts_by_author/`, and `/search/`. See [Deprecated Endpoints](/api-reference/deprecated).
 </Info>
 
-#### Response Fields
+<ResponseExample>
 
-Each post contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique post identifier |
-| `title` | string | Post headline |
-| `slug` | string | URL-friendly slug |
-| `type` | string | Post type |
-| `banner_url` | string | Featured image URL |
-| `short_description` | string | Summary / meta description |
-| `summary` | string | Post summary below title |
-| `primary_category` | object | Primary category (`id`, `name`, `slug`) |
-| `categories` | array | All assigned categories |
-| `tags` | array | Assigned tags |
-| `contributors` | array | Authors/contributors |
-| `content_html` | string | Full HTML content |
-| `content_json` | array | Structured content blocks |
-| `meta_data` | object | SEO, access type, schema data |
-| `media_file_banner` | object | Banner media details (`id`, `filename`, `path`, `alt_text`, `meta_data`) |
-| `word_count` | integer | Article word count |
-| `access_type` | string | `Free` or `Paid` |
-| `language_code` | string | Content language code |
-| `blog_update` | array | Live blog updates (for LiveBlog type) |
-| `custom_entity` | object/null | Custom entity data |
-| `hide_banner_image` | boolean | Whether banner image is hidden |
-| `banner_description` | string | Banner image caption |
-| `absolute_url` | string | Full public URL path |
-| `formatted_first_published_at_datetime` | string | First published timestamp |
-| `formatted_last_published_at_datetime` | string | Last published timestamp |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -173,14 +141,12 @@ Each post contains:
   "per_page": 10
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/publisher-data.mdx
+++ b/api-reference/content-delivery/publisher-data.mdx
@@ -18,24 +18,9 @@ Returns the complete publisher profile including branding, configuration, social
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `name` | string | Publisher name |
-| `logo` | string | Logo URL |
-| `favicon` | string | Favicon URL |
-| `primary_color` | string | Brand primary color (hex) |
-| `secondary_color` | string | Brand secondary color (hex) |
-| `social_links` | object | Social media profile URLs |
-| `meta_title` | string | Default SEO meta title |
-| `meta_description` | string | Default SEO meta description |
-| `reader_login_config` | object | Reader login/paywall configuration |
-| `ad_configurations` | object | Advertisement configuration settings |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -55,14 +40,12 @@ Returns the complete publisher profile including branding, configuration, social
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/tag-details.mdx
+++ b/api-reference/content-delivery/tag-details.mdx
@@ -22,27 +22,9 @@ Returns detailed information about a single tag, including SEO metadata and soci
   API Secret
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique tag identifier |
-| `name` | string | Tag name |
-| `slug` | string | URL-friendly slug |
-| `display_name` | string/null | Alternative display name |
-| `meta_title` | string | SEO meta title |
-| `meta_description` | string | SEO meta description |
-| `og_title` | string | Open Graph title |
-| `og_description` | string | Open Graph description |
-| `og_image` | string | Open Graph image URL |
-| `twitter_title` | string | Twitter Card title |
-| `twitter_description` | string | Twitter Card description |
-| `twitter_image` | string | Twitter Card image URL |
-| `absolute_url` | string | Full public URL path |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": {
@@ -63,14 +45,12 @@ Returns detailed information about a single tag, including SEO metadata and soci
   "message": ""
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-delivery/tag-listing.mdx
+++ b/api-reference/content-delivery/tag-listing.mdx
@@ -26,20 +26,9 @@ Returns a paginated list of all tags.
   Items per page (max: 50)
 </ParamField>
 
-#### Response Fields
+<ResponseExample>
 
-Each tag contains:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `id` | integer | Unique tag identifier |
-| `name` | string | Tag name |
-| `slug` | string | URL-friendly slug |
-| `absolute_url` | string | Full public URL path |
-
-<Tabs>
-<Tab title="200: OK">
-```json
+```json 200
 {
   "status": "ok",
   "data": [
@@ -61,14 +50,12 @@ Each tag contains:
   "per_page": 10
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/categories/create-category.mdx
+++ b/api-reference/content-management/categories/create-category.mdx
@@ -74,9 +74,9 @@ curl -X POST \
   }'
 ```
 
-<Tabs>
-<Tab title="201: Created">
-```json
+<ResponseExample>
+
+```json 201
 {
   "status": "success",
   "message": "Created Successfully",
@@ -95,19 +95,15 @@ curl -X POST \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="400: Bad Request">
-```json
+```json 400
 {
   "error": {
     "code": "BAD_REQUEST_ERROR",
@@ -115,5 +111,5 @@ curl -X POST \
   }
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/categories/delete-category.mdx
+++ b/api-reference/content-management/categories/delete-category.mdx
@@ -26,31 +26,27 @@ Permanently deletes a category.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/categories/list-categories.mdx
+++ b/api-reference/content-management/categories/list-categories.mdx
@@ -26,9 +26,9 @@ Returns a paginated list of all categories.
   Items per page (max: 50)
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "count": 477,
   "next": "https://cms.thepublive.com/publisher/123/category/?page=2&limit=10",
@@ -50,14 +50,12 @@ Returns a paginated list of all categories.
   ]
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/categories/retrieve-category.mdx
+++ b/api-reference/content-management/categories/retrieve-category.mdx
@@ -22,9 +22,9 @@ Returns the details of a specific category.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "id": 14428,
   "name": "News",
@@ -39,23 +39,19 @@ Returns the details of a specific category.
   "content_type": null
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/categories/update-category.mdx
+++ b/api-reference/content-management/categories/update-category.mdx
@@ -57,9 +57,9 @@ curl -X PATCH \
   -d '{"name": "Latest News", "meta_title": "Latest News Updates"}'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Updated Successfully",
@@ -78,14 +78,12 @@ curl -X PATCH \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/media/create-media.mdx
+++ b/api-reference/content-management/media/create-media.mdx
@@ -62,9 +62,9 @@ curl -X POST \
   }'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Created Successfully",
@@ -82,14 +82,12 @@ curl -X POST \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/media/delete-media.mdx
+++ b/api-reference/content-management/media/delete-media.mdx
@@ -26,22 +26,20 @@ Permanently deletes a media asset from the library.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/media/list-media.mdx
+++ b/api-reference/content-management/media/list-media.mdx
@@ -26,9 +26,9 @@ Returns a paginated list of all media assets in your library.
   Items per page (max: 50)
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "count": 15420,
   "next": "https://cms.thepublive.com/publisher/123/media-library/?page=2&limit=10",
@@ -52,14 +52,12 @@ Returns a paginated list of all media assets in your library.
   ]
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/media/retrieve-media.mdx
+++ b/api-reference/content-management/media/retrieve-media.mdx
@@ -22,9 +22,9 @@ Returns the details of a specific media asset.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "id": 999,
   "filename": "budget-2026.jpg",
@@ -41,14 +41,12 @@ Returns the details of a specific media asset.
   "member": "admin"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/media/update-media.mdx
+++ b/api-reference/content-management/media/update-media.mdx
@@ -53,9 +53,9 @@ curl -X PATCH \
   -d '{"source": "Reuters", "alt_text": "Updated alt text"}'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Updated Successfully",
@@ -71,14 +71,12 @@ curl -X PATCH \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/posts/create-post.mdx
+++ b/api-reference/content-management/posts/create-post.mdx
@@ -115,9 +115,9 @@ curl -X POST \
   }'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Created successfully",
@@ -152,19 +152,15 @@ curl -X POST \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="400: Bad Request">
-```json
+```json 400
 {
   "error": {
     "code": "BAD_REQUEST_ERROR",
@@ -172,5 +168,5 @@ curl -X POST \
   }
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/posts/delete-post.mdx
+++ b/api-reference/content-management/posts/delete-post.mdx
@@ -26,31 +26,27 @@ Permanently deletes a post.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/posts/list-posts.mdx
+++ b/api-reference/content-management/posts/list-posts.mdx
@@ -26,9 +26,9 @@ Returns a paginated list of all posts (including drafts, published, and schedule
   Items per page (max: 50)
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "count": 33145,
   "next": "https://cms.thepublive.com/publisher/123/post/?page=2&limit=10",
@@ -70,14 +70,12 @@ Returns a paginated list of all posts (including drafts, published, and schedule
   ]
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/posts/retrieve-post.mdx
+++ b/api-reference/content-management/posts/retrieve-post.mdx
@@ -22,9 +22,9 @@ Returns the complete details of a specific post.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "id": 50123,
   "title": "Union Budget 2026 Highlights",
@@ -72,23 +72,19 @@ Returns the complete details of a specific post.
   "source": "HeadlessCMS"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
 
-<Tab title="404: Not Found">
-```json
+```json 404
 {
   "status": "error",
   "message": "Not found"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/posts/update-post.mdx
+++ b/api-reference/content-management/posts/update-post.mdx
@@ -79,9 +79,9 @@ curl -X PATCH \
   -d '{"status": "Published", "title": "Updated Title"}'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Updated Successfully",
@@ -99,14 +99,12 @@ curl -X PATCH \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/tags/create-tag.mdx
+++ b/api-reference/content-management/tags/create-tag.mdx
@@ -49,9 +49,9 @@ curl -X POST \
   -d '{"name": "AI Technology", "english_name": "AI Technology"}'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Created Successfully",
@@ -66,14 +66,12 @@ curl -X POST \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/tags/delete-tag.mdx
+++ b/api-reference/content-management/tags/delete-tag.mdx
@@ -22,22 +22,20 @@ Permanently deletes a tag.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Deleted successfully!"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/tags/list-tags.mdx
+++ b/api-reference/content-management/tags/list-tags.mdx
@@ -26,9 +26,9 @@ Returns a paginated list of all tags.
   Items per page (max: 50)
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "count": 112118,
   "next": "https://cms.thepublive.com/publisher/123/tag/?page=2&limit=10",
@@ -46,14 +46,12 @@ Returns a paginated list of all tags.
   ]
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/tags/retrieve-tag.mdx
+++ b/api-reference/content-management/tags/retrieve-tag.mdx
@@ -22,9 +22,9 @@ Returns the details of a specific tag.
   API Secret
 </ParamField>
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "id": 500,
   "name": "Breaking News",
@@ -35,14 +35,12 @@ Returns the details of a specific tag.
   "meta_description": "Latest breaking news stories"
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>

--- a/api-reference/content-management/tags/update-tag.mdx
+++ b/api-reference/content-management/tags/update-tag.mdx
@@ -49,9 +49,9 @@ curl -X PATCH \
   -d '{"name": "Breaking News Updated"}'
 ```
 
-<Tabs>
-<Tab title="200: OK">
-```json
+<ResponseExample>
+
+```json 200
 {
   "status": "success",
   "message": "Updated Successfully",
@@ -66,14 +66,12 @@ curl -X PATCH \
   }
 }
 ```
-</Tab>
 
-<Tab title="401: Unauthorized">
-```json
+```json 401
 {
   "status": "error",
   "message": "Unauthorized"
 }
 ```
-</Tab>
-</Tabs>
+
+</ResponseExample>


### PR DESCRIPTION
Convert all 36 API endpoint files from custom <Tabs>/<Tab> response examples to Mintlify's native <ResponseExample> component, which pins responses in the right sidebar. Also remove redundant Response Fields markdown tables from 16 Content Delivery API files, as the JSON examples themselves document the response structure.

https://claude.ai/code/session_01F2Nnrn4f2hJ13UjGV6eHpq