### PR TITLE
explicitly state that the endpoint is for registering existing media …

### DIFF
--- a/api-reference/content-management/media/create-media.mdx
+++ b/api-reference/content-management/media/create-media.mdx
@@ -1,10 +1,17 @@
 ---
-title: "Create Media"
-description: Create/upload a media asset
+title: "Register Media"
+description: Register an existing media URL to the CMS library
 api: "POST https://cms.thepublive.com/publisher/{publisher_id}/media-library/"
 ---
 
-Creates a new media entry in the library.
+Registers an existing media URL to the CMS library. 
+
+<Warning>
+**This endpoint does not support direct file uploads.**
+It expects a standard JSON payload containing a direct URL (`path`) to an image or file hosted on an external server (e.g., S3, Cloudinary). Sending `multipart/form-data` or binary files will result in a server error.
+</Warning>
+
+Creates a new media entry in the library using an external URL.
 
 <ParamField path="publisher_id" type="string" required>
   Your Publisher ID

--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -10,9 +10,10 @@ This guide walks you through making your first API call to Publive.
 The Publive API uses HTTP Basic Auth. You need your **API Key**, **API Secret**, and **Publisher ID**.
 
 1. Log in to your [Publive Dashboard](https://dashboard.thepublive.com/v2/configurations/api-developer-hub).
-2. Click the **View API credentials** button.
-3. Copy your **API Key** and **API Secret**.
-4. Note your **Publisher ID** from the dashboard URL.
+2. Navigate to **configurations** > **API Developer Hub**.
+3. Click the **View API credentials** button.
+4. Copy your **API Key** and **API Secret**.
+5. Note your **Publisher ID** from the dashboard URL.
 
 <Note>
 If you do not have dashboard access, please reach out via our [contact page](https://thepublive.com/contact-us).


### PR DESCRIPTION
…URLs via a JSON payload and does not support direct binary file uploads. Issue #39 