### PR TITLE
Add Live Blog Update API endpoints documentation

### DIFF
--- a/api-reference/content-management/posts/README.mdx
+++ b/api-reference/content-management/posts/README.mdx
@@ -42,3 +42,5 @@ Posts are the primary content entity in Publive. They support multiple content t
 | [GET](/api-reference/content-management/posts/retrieve-post) | `/post/{id}/` | Retrieve a post |
 | [PATCH](/api-reference/content-management/posts/update-post) | `/post/{id}/` | Update a post |
 | [DELETE](/api-reference/content-management/posts/delete-post) | `/post/{id}/` | Delete a post |
+| [POST](/api-reference/content-management/posts/create-live-blog-update) | `/post/{post_id}/live-blog-update/` | Create a live blog update |
+| [PATCH](/api-reference/content-management/posts/update-live-blog-update) | `/post/{post_id}/live-blog-update/{id}/` | Update a live blog update |

--- a/api-reference/content-management/posts/create-live-blog-update.mdx
+++ b/api-reference/content-management/posts/create-live-blog-update.mdx
@@ -1,0 +1,82 @@
+---
+title: "Create Live Blog Update"
+description: Add a new update entry to a LiveBlog post
+api: "POST https://cms.thepublive.com/publisher/{publisher_id}/post/{post_id}/live-blog-update/"
+---
+
+Adds a new update entry to a LiveBlog post. Each update has its own title, HTML content, and is attributed to the authenticated author.
+
+<Info>
+This endpoint only applies to posts with `type: "LiveBlog"`. For other post types, use the [Update Post](/api-reference/content-management/posts/update-post) endpoint.
+</Info>
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ParamField path="post_id" type="integer" required>
+  The post ID of the LiveBlog
+</ParamField>
+
+<ParamField body="title" type="string" required>
+  Headline for this update entry
+</ParamField>
+
+<ParamField body="content" type="string" required>
+  HTML body content for this update entry
+</ParamField>
+
+#### Example request
+
+```bash
+curl --request POST \
+  --url https://cms.thepublive.com/publisher/1/post/11075/live-blog-update/ \
+  --header 'Authorization: Basic {auth_token}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "title": "Update test API 2",
+    "content": "<p>Update testAPI</p>"
+}'
+```
+
+<ResponseExample>
+
+```json 201
+{
+  "status": 201,
+  "message": "Created successfully",
+  "data": {
+    "id": 4,
+    "published_post": 9878,
+    "author": {
+      "name": "PL",
+      "slug": "PL",
+      "description": "",
+      "facebook": "",
+      "linkedin": "",
+      "instagram": "",
+      "twitter": "",
+      "avatar": "test_1/media/member_avatars/2025/06/04/2025-06-04t062423556z-2sb0dogg9lqdjohcy4zk-20b3e10e.webp"
+    },
+    "content": {
+      "title": "Update test API 2",
+      "content": "<p>Update testAPI</p>"
+    },
+    "created_at": "2026-04-13T18:00:51.784995+05:30",
+    "updated_at": "2026-04-13T18:00:51.785034+05:30",
+    "is_pinned": false,
+    "Cache-Tags": [
+      "PublishedPostComments.4",
+      "RE-MD.135"
+    ]
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-management/posts/update-live-blog-update.mdx
+++ b/api-reference/content-management/posts/update-live-blog-update.mdx
@@ -1,0 +1,86 @@
+---
+title: "Update Live Blog Update"
+description: Update an existing live blog update entry
+api: "PATCH https://cms.thepublive.com/publisher/{publisher_id}/post/{post_id}/live-blog-update/{id}/"
+---
+
+Updates an existing live blog update entry. Only send the fields you want to change.
+
+<Info>
+This endpoint only applies to posts with `type: "LiveBlog"`. For other post types, use the [Update Post](/api-reference/content-management/posts/update-post) endpoint.
+</Info>
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ParamField path="post_id" type="integer" required>
+  The post ID of the LiveBlog
+</ParamField>
+
+<ParamField path="id" type="integer" required>
+  The ID of the live blog update entry to update
+</ParamField>
+
+<ParamField body="title" type="string">
+  Headline for this update entry
+</ParamField>
+
+<ParamField body="content" type="string">
+  HTML body content for this update entry
+</ParamField>
+
+#### Example request
+
+```bash
+curl --request PATCH \
+  --url https://cms.thepublive.com/publisher/1/post/11075/live-blog-update/4/ \
+  --header 'Authorization: Basic {auth_token}' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "title": "Update test API 3",
+    "content": "<p>Update testAPI</p>"
+}'
+```
+
+<ResponseExample>
+
+```json 200
+{
+  "status": 200,
+  "message": "Updated Successfully",
+  "data": {
+    "id": 4,
+    "published_post": 9878,
+    "author": {
+      "name": "PL",
+      "slug": "PL",
+      "description": "",
+      "facebook": "",
+      "linkedin": "",
+      "instagram": "",
+      "twitter": "",
+      "avatar": "test_1/media/member_avatars/2025/06/04/2025-06-04t062423556z-2sb0dogg9lqdjohcy4zk-20b3e10e.webp"
+    },
+    "content": {
+      "title": "Update test API 3",
+      "content": "<p>Update testAPI</p>"
+    },
+    "created_at": "2026-04-13T18:00:51.784995+05:30",
+    "updated_at": "2026-04-13T18:02:08.031108+05:30",
+    "is_pinned": false,
+    "Cache-Tags": [
+      "PublishedPostComments.4",
+      "RE-MD.135"
+    ]
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+</ResponseExample>

--- a/docs.json
+++ b/docs.json
@@ -207,7 +207,9 @@
                   "api-reference/content-management/posts/create-post",
                   "api-reference/content-management/posts/retrieve-post",
                   "api-reference/content-management/posts/update-post",
-                  "api-reference/content-management/posts/delete-post"
+                  "api-reference/content-management/posts/delete-post",
+                  "api-reference/content-management/posts/create-live-blog-update",
+                  "api-reference/content-management/posts/update-live-blog-update"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
Added API documentation for creating and updating live blog update entries, enabling users to manage individual updates within LiveBlog posts.

## Key Changes
- **New endpoint documentation**: Created `create-live-blog-update.mdx` documenting the POST endpoint for adding new update entries to LiveBlog posts
- **New endpoint documentation**: Created `update-live-blog-update.mdx` documenting the PATCH endpoint for modifying existing live blog update entries
- **Updated navigation**: Added both new endpoints to the documentation structure in `docs.json`
- **Updated README**: Added entries to the Posts API reference table documenting the new live blog update endpoints

## Implementation Details
- Both endpoints are specific to posts with `type: "LiveBlog"` and include informational notes directing users to the standard Update Post endpoint for other post types
- Create endpoint accepts required `title` and `content` fields, returning a 201 status with the created update object
- Update endpoint accepts optional `title` and `content` fields for partial updates, returning a 200 status with the updated object
- Both endpoints include complete curl examples and response examples showing successful operations and authentication error cases
- Response objects include author information, timestamps, pinned status, and cache tags

https://claude.ai/code/session_01UxUJGY5sTDm3QXQKqLnbgV