### PR TITLE
moved backdate section from approval flows to migration guide, added…

### DIFF
--- a/api-reference/content-management/posts/update-post.mdx
+++ b/api-reference/content-management/posts/update-post.mdx
@@ -30,6 +30,10 @@ Send only the fields you wish to update. Common fields:
   `Draft`, `Published`, `Scheduled`, `Approval Pending`
 </ParamField>
 
+<ParamField body="custom_published_at" type="string">
+  ISO 8601 timestamp for backdated publishing (e.g., `2025-12-15T10:00:00Z`). See the [Migration Guides](/documentation/reference/migration-guides#backdated-publishing) for details.
+</ParamField>
+
 <ParamField body="primary_category" type="integer">
   Category ID
 </ParamField>

--- a/documentation/guides/workflows/approval-flow.mdx
+++ b/documentation/guides/workflows/approval-flow.mdx
@@ -59,20 +59,6 @@ curl -X PATCH \
   }'
 ```
 
-## Backdated publishing
-
-For content that needs a custom publication date (e.g., migrated content):
-
-```bash
-curl -X PATCH \
-  'https://cms.thepublive.com/publisher/<PUBLISHER_ID>/post/<POST_ID>/' \
-  -H 'Authorization: Basic <BASE64_AUTH_TOKEN>' \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "status": "Published",
-    "custom_published_at": "2025-12-15T10:00:00Z"
-  }'
-```
 
 <Info>
 The `published_post` field in the post response references the live version, while edits can be made to the draft version independently.

--- a/documentation/guides/workflows/state-management.mdx
+++ b/documentation/guides/workflows/state-management.mdx
@@ -39,6 +39,10 @@ graph TD
 | `Scheduled` | `Draft` | Cancel scheduled publish |
 | `Scheduled` | `Published` | Auto-triggered at `scheduled_at` time |
 
+## Backdated publishing
+
+To retroactively set a publication date for migrated or historical content, override the timestamp using `custom_published_at`. See [Migration Guides](/documentation/reference/migration-guides#backdated-publishing) for details.
+
 ## Checking post status
 
 Use the CMS API to check current status:

--- a/documentation/reference/migration-guides.mdx
+++ b/documentation/reference/migration-guides.mdx
@@ -136,3 +136,22 @@ The new `/posts/` endpoint provides:
 -  Test that response data matches expected format
 -  Update any response parsing (field names are consistent)
 -  Monitor for deprecation warnings in API responses
+
+## Content Migration Strategies
+
+### Backdated Publishing
+
+When migrating historical content from legacy systems, you must preserve the original publication dates instead of using the time of import.
+
+You can accomplish this by directly updating the post with the `custom_published_at` property:
+
+```bash
+curl -X PATCH \
+  'https://cms.thepublive.com/publisher/<PUBLISHER_ID>/post/<POST_ID>/' \
+  -H 'Authorization: Basic <BASE64_AUTH_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "status": "Published",
+    "custom_published_at": "2025-12-15T10:00:00Z"
+  }'
+```


### PR DESCRIPTION
… crosslinks to update post & state management