### PR TITLE
Add a guide explaining how to embed Schema.org-compliant FAQ HTML blocks

### DIFF
--- a/api-reference/content-management/posts/create-post.mdx
+++ b/api-reference/content-management/posts/create-post.mdx
@@ -37,7 +37,7 @@ Creates a new post. Posts are created with `Draft` status by default.
 </ParamField>
 
 <ParamField body="content" type="string">
-  HTML body content
+  HTML body content. Supports structured blocks such as [FAQ sections](/documentation/guides/content-authoring/faq-block).
 </ParamField>
 
 <ParamField body="tags" type="string">

--- a/api-reference/content-management/posts/update-post.mdx
+++ b/api-reference/content-management/posts/update-post.mdx
@@ -23,7 +23,7 @@ Send only the fields you wish to update. Common fields:
 </ParamField>
 
 <ParamField body="content" type="string">
-  HTML body content
+  HTML body content. Supports structured blocks such as [FAQ sections](/documentation/guides/content-authoring/faq-block).
 </ParamField>
 
 <ParamField body="status" type="string">

--- a/docs.json
+++ b/docs.json
@@ -18,9 +18,12 @@
     "timestamp": true
   },
   "colors": {
-    "primary": "#21263c",
-    "light": "#21263c",
-    "dark": "#21263c"
+    "primary": "#146EF5",
+    "light": "#146EF5",
+    "dark": "#146EF5"
+  },
+  "styling": {
+    "eyebrows": "breadcrumbs"
   },
   "favicon": "https://dashboard.thepublive.com/v2/public/favicon.ico",
   "navigation": {
@@ -116,6 +119,12 @@
               "documentation/guides/industry-specific/media-publishing",
               "documentation/guides/industry-specific/bfsi-compliance",
               "documentation/guides/industry-specific/pharma-governance"
+            ]
+          },
+          {
+            "group": "Content Authoring",
+            "pages": [
+              "documentation/guides/content-authoring/faq-block"
             ]
           },
           {
@@ -279,7 +288,7 @@
     "links": [
       {
         "label": "Support",
-        "href": "mailto:help@thepublive.com"
+        "href": "https://help.thepublive.com/support/solutions"
       }
     ],
     "primary": {
@@ -310,9 +319,6 @@
   "appearance": {
     "strict": true,
     "default": "light"
-  },
-  "background": {
-    "decoration": "grid"
   },
   "api": {
     "mdx": {

--- a/documentation/guides/content-authoring/faq-block.mdx
+++ b/documentation/guides/content-authoring/faq-block.mdx
@@ -1,0 +1,89 @@
+---
+title: "FAQ Block"
+description: Add structured FAQ sections to post content using the Create Post and Update Post APIs
+---
+
+The `content` field in [Create Post](/api-reference/content-management/posts/create-post) and [Update Post](/api-reference/content-management/posts/update-post) accepts HTML. To add a FAQ section, embed the following block anywhere within the HTML body.
+
+<Note>
+  `contributors` and `primary_category` are required fields when creating or updating a post that contains a FAQ block.
+</Note>
+
+## FAQ HTML Structure
+
+```html
+<div class="faq-block-html noneditable" itemscope="" itemtype="https://schema.org/FAQPage">
+  <h3>FAQ</h3>
+  <div class="faq-section">
+    <div class="faq-pair-html" itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question">
+      <div class="question-html"><label> Q. </label>
+        <div itemprop="name">Question Placeholder</div>
+      </div>
+      <div class="answer-html" itemscope="" itemprop="acceptedAnswer" itemtype="https://schema.org/Answer"><label> A. </label>
+        <div class="noneditable" itemprop="text">Answer Placeholder</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Replace `Question Placeholder` and `Answer Placeholder` with your content. Add more `faq-pair-html` divs inside `faq-section` for additional Q&A pairs.
+
+## Multiple Questions
+
+```html
+<div class="faq-block-html noneditable" itemscope="" itemtype="https://schema.org/FAQPage">
+  <h3>FAQ</h3>
+  <div class="faq-section">
+
+    <div class="faq-pair-html" itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question">
+      <div class="question-html"><label> Q. </label>
+        <div itemprop="name">What is Publive?</div>
+      </div>
+      <div class="answer-html" itemscope="" itemprop="acceptedAnswer" itemtype="https://schema.org/Answer"><label> A. </label>
+        <div class="noneditable" itemprop="text">Publive is a headless CMS built for digital publishers.</div>
+      </div>
+    </div>
+
+    <div class="faq-pair-html" itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question">
+      <div class="question-html"><label> Q. </label>
+        <div itemprop="name">How do I authenticate API requests?</div>
+      </div>
+      <div class="answer-html" itemscope="" itemprop="acceptedAnswer" itemtype="https://schema.org/Answer"><label> A. </label>
+        <div class="noneditable" itemprop="text">Pass a Base64-encoded credential in the Authorization header using HTTP Basic Auth.</div>
+      </div>
+    </div>
+
+  </div>
+</div>
+```
+
+## Example API Request
+
+```bash
+curl -X POST \
+  'https://cms.thepublive.com/publisher/123/post/' \
+  -H 'Authorization: Basic <BASE64_AUTH_TOKEN>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "title": "Common Questions About Our Service",
+    "english_title": "Common Questions About Our Service",
+    "type": "Article",
+    "status": "Draft",
+    "primary_category": 100,
+    "contributors": "1",
+    "content": "<div class=\"faq-block-html noneditable\" itemscope=\"\" itemtype=\"https://schema.org/FAQPage\"><h3>FAQ</h3><div class=\"faq-section\"><div class=\"faq-pair-html\" itemscope=\"\" itemprop=\"mainEntity\" itemtype=\"https://schema.org/Question\"><div class=\"question-html\"><label> Q. </label><div itemprop=\"name\">What is Publive?</div></div><div class=\"answer-html\" itemscope=\"\" itemprop=\"acceptedAnswer\" itemtype=\"https://schema.org/Answer\"><label> A. </label><div class=\"noneditable\" itemprop=\"text\">Publive is a headless CMS built for digital publishers.</div></div></div></div></div>"
+  }'
+```
+
+## Schema.org Markup
+
+The FAQ block uses [Schema.org FAQPage](https://schema.org/FAQPage) structured data, which enables rich results in Google Search.
+
+| Class | Property | Purpose |
+| ----- | -------- | ------- |
+| `FAQPage` | — | Marks the block as a FAQ page |
+| `Question` | `mainEntity` | Each Q&A pair |
+| `Question` | `name` | The question text |
+| `Answer` | `acceptedAnswer` | The answer container |
+| `Answer` | `text` | The answer text |


### PR DESCRIPTION
in the post content field. Cross-reference it from the Create Post and Update Post API pages. Register the new Content Authoring group in the Guides navigation.