### PR TITLE
feat: add static files and sitemaps documentation to Content Delivery…

### DIFF
--- a/api-reference/content-delivery/README.mdx
+++ b/api-reference/content-delivery/README.mdx
@@ -43,6 +43,26 @@ The Content Delivery Service (CDS) provides read-only access to your published c
 | [Post Details by URL](/api-reference/content-delivery/post-details-by-url) | Get a post by its legacy/relative URL       |
 | [Live Blog Updates](/api-reference/content-delivery/live-blog-updates)     | Get live blog update entries for a post     |
 
+## Static Files
+
+| Endpoint                                                                                              | Description                                        |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [ads.txt](/api-reference/content-delivery/static-ads-txt)                                             | Publisher's ads.txt file                           |
+| [robots.txt](/api-reference/content-delivery/static-robots-txt)                                       | Publisher's robots.txt file                        |
+| [service-worker.js](/api-reference/content-delivery/static-service-worker)                            | Push notification service worker script            |
+| [Push Notification HTML](/api-reference/content-delivery/static-push-notification-html)               | iZooto permission UI HTML files                    |
+
+## Sitemaps
+
+| Endpoint                                                                                              | Description                                        |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| [All-content Sitemap](/api-reference/content-delivery/sitemap-allcontent)                             | Master sitemap index for all content               |
+| [Web Content Sitemap](/api-reference/content-delivery/sitemap-webcontent)                             | Index linking to paginated article sitemaps        |
+| [News Sitemap](/api-reference/content-delivery/sitemap-news)                                          | Google News sitemap                                |
+| [Category Sitemap](/api-reference/content-delivery/sitemap-category)                                  | Sitemap of all category pages                      |
+| [Web Story Sitemap](/api-reference/content-delivery/sitemap-webstory)                                 | Index linking to paginated web story sitemaps      |
+| [Paginated Sitemaps](/api-reference/content-delivery/sitemap-paginated)                               | Date-stamped article and web story sitemap pages   |
+
 ## Pagination
 
 All list endpoints support pagination:

--- a/api-reference/content-delivery/sitemap-allcontent.mdx
+++ b/api-reference/content-delivery/sitemap-allcontent.mdx
@@ -1,0 +1,36 @@
+---
+title: "All-content Sitemap"
+description: Fetch the publisher's master sitemap index
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/allcontent-sitemap.xml/"
+---
+
+Returns the master sitemap XML for all published content. This is typically the top-level sitemap index that links to individual category, tag, and content sitemaps.
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <sitemap>\n    <loc>https://www.example.com/sitemap/webcontent-sitemap.xml</loc>\n    <lastmod>2026-05-29</lastmod>\n  </sitemap>\n  <sitemap>\n    <loc>https://www.example.com/sitemap/news-sitemap.xml</loc>\n    <lastmod>2026-05-29</lastmod>\n  </sitemap>\n</sitemapindex>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/sitemap-category.mdx
+++ b/api-reference/content-delivery/sitemap-category.mdx
@@ -1,0 +1,36 @@
+---
+title: "Category Sitemap"
+description: Fetch the publisher's category sitemap
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/category-sitemap.xml/"
+---
+
+Returns the sitemap XML listing all published category pages for the publisher.
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url>\n    <loc>https://www.example.com/sports</loc>\n    <lastmod>2026-05-29</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n  <url>\n    <loc>https://www.example.com/economy</loc>\n    <lastmod>2026-05-29</lastmod>\n    <changefreq>daily</changefreq>\n    <priority>0.8</priority>\n  </url>\n</urlset>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/sitemap-news.mdx
+++ b/api-reference/content-delivery/sitemap-news.mdx
@@ -1,0 +1,36 @@
+---
+title: "News Sitemap"
+description: Fetch the publisher's Google News sitemap
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/news-sitemap.xml/"
+---
+
+Returns the Google News sitemap XML containing recently published articles eligible for Google News indexing.
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\" xmlns:news=\"http://www.google.com/schemas/sitemap-news/0.9\">\n  <url>\n    <loc>https://www.example.com/sports/ipl-2026-final-98201</loc>\n    <news:news>\n      <news:publication>\n        <news:name>My Publication</news:name>\n        <news:language>en</news:language>\n      </news:publication>\n      <news:publication_date>2026-05-25T21:00:00Z</news:publication_date>\n      <news:title>IPL 2026 Final: Highlights and Scorecard</news:title>\n    </news:news>\n  </url>\n</urlset>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/sitemap-paginated.mdx
+++ b/api-reference/content-delivery/sitemap-paginated.mdx
@@ -1,0 +1,66 @@
+---
+title: "Paginated Sitemaps"
+description: Fetch date-stamped paginated sitemaps for articles and web stories
+---
+
+Two date-stamped URL patterns serve paginated content sitemaps. Both are generated automatically by Publive and linked from their respective index sitemaps.
+
+## Article Sitemap Page
+
+`GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/sitemap_{date}.xml/`
+
+Returns a paginated batch of article URLs for the given date partition.
+
+**S3 path:** `<slug>/sitemaps/allsitemaps/webcontent-sitemaps/sitemap_<date>.xml`
+
+## Web Story Sitemap Page
+
+`GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/webstory_sitemap_{date}.xml/`
+
+Returns a paginated batch of web story URLs for the given date partition.
+
+**S3 path:** `<slug>/sitemaps/allsitemaps/webstory-sitemaps/webstory_sitemap_<date>.xml`
+
+---
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ParamField path="date" type="string" required>
+  Date partition identifier embedded in the filename (e.g. `2026-05-01`). Discover valid values from the index sitemaps: [Web Content Sitemap](/api-reference/content-delivery/sitemap-webcontent) and [Web Story Sitemap](/api-reference/content-delivery/sitemap-webstory).
+</ParamField>
+
+<ResponseExample>
+
+```json 200 Article sitemap page
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url>\n    <loc>https://www.example.com/sports/ipl-2026-final-98201</loc>\n    <lastmod>2026-05-25</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>\n</urlset>"
+  }
+}
+```
+
+```json 200 Web story sitemap page
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <url>\n    <loc>https://www.example.com/web-stories/ipl-highlights-story</loc>\n    <lastmod>2026-05-25</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>0.6</priority>\n  </url>\n</urlset>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/sitemap-webcontent.mdx
+++ b/api-reference/content-delivery/sitemap-webcontent.mdx
@@ -1,0 +1,36 @@
+---
+title: "Web Content Sitemap"
+description: Fetch the publisher's web content sitemap index
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/webcontent-sitemap.xml/"
+---
+
+Returns the web content sitemap XML, which acts as an index linking to paginated article sitemaps (`sitemap_<date>.xml`).
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <sitemap>\n    <loc>https://www.example.com/sitemap/sitemap_2026-05-01.xml</loc>\n    <lastmod>2026-05-01</lastmod>\n  </sitemap>\n  <sitemap>\n    <loc>https://www.example.com/sitemap/sitemap_2026-04-01.xml</loc>\n    <lastmod>2026-04-01</lastmod>\n  </sitemap>\n</sitemapindex>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/sitemap-webstory.mdx
+++ b/api-reference/content-delivery/sitemap-webstory.mdx
@@ -1,0 +1,36 @@
+---
+title: "Web Story Sitemap"
+description: Fetch the publisher's web story sitemap index
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/sitemap/webstory-sitemap.xml/"
+---
+
+Returns the web story sitemap XML, which acts as an index linking to paginated web story sitemaps (`webstory_sitemap_<date>.xml`).
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n  <sitemap>\n    <loc>https://www.example.com/sitemap/webstory_sitemap_2026-05-01.xml</loc>\n    <lastmod>2026-05-01</lastmod>\n  </sitemap>\n  <sitemap>\n    <loc>https://www.example.com/sitemap/webstory_sitemap_2026-04-01.xml</loc>\n    <lastmod>2026-04-01</lastmod>\n  </sitemap>\n</sitemapindex>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/static-ads-txt.mdx
+++ b/api-reference/content-delivery/static-ads-txt.mdx
@@ -1,0 +1,36 @@
+---
+title: "ads.txt"
+description: Fetch the publisher's ads.txt file
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/static/ads.txt/"
+---
+
+Returns the raw text content of the publisher's `ads.txt` file, served from S3.
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "google.com, pub-0000000000000000, DIRECT, f08c47fec0942fa0\nexchangeone.com, 12345, RESELLER"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/static-push-notification-html.mdx
+++ b/api-reference/content-delivery/static-push-notification-html.mdx
@@ -1,0 +1,54 @@
+---
+title: "Push Notification HTML"
+description: Fetch push-notification HTML helper files (izooto.html, helper-iframe.html, permission-dialog.html)
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/static/{filename}/"
+---
+
+Returns one of three HTML files required to render the push notification permission UI on the publisher's website.
+
+<Warning>
+  All three files return `404` if push notifications are not enabled for the publisher. Check `publisher_config → widget_config_json → push_notification_config` to determine availability.
+</Warning>
+
+<Info>
+  The file is resolved in two steps: first a publisher-specific override is looked up in S3; if not found, a shared default is fetched from the Publive CDN. This means the response content may differ per publisher.
+</Info>
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ParamField path="filename" type="string" required>
+  The name of the HTML file to fetch.
+
+  | Value                   | Description                                     |
+  | ----------------------- | ----------------------------------------------- |
+  | `izooto.html`           | Main iZooto push notification integration page  |
+  | `helper-iframe.html`    | Hidden iframe used for cross-origin permission  |
+  | `permission-dialog.html`| Permission prompt dialog rendered to the user   |
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "<!DOCTYPE html><html><head>...</head><body>...</body></html>"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "Push notifications are not enabled for this publisher"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/static-robots-txt.mdx
+++ b/api-reference/content-delivery/static-robots-txt.mdx
@@ -1,0 +1,36 @@
+---
+title: "robots.txt"
+description: Fetch the publisher's robots.txt file
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/static/robots.txt/"
+---
+
+Returns the raw text content of the publisher's `robots.txt` file, served from S3.
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "User-agent: *\nDisallow: /admin/\nAllow: /\nSitemap: https://www.example.com/sitemap/allcontent-sitemap.xml"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "File not found"
+}
+```
+
+</ResponseExample>

--- a/api-reference/content-delivery/static-service-worker.mdx
+++ b/api-reference/content-delivery/static-service-worker.mdx
@@ -1,0 +1,40 @@
+---
+title: "service-worker.js"
+description: Fetch the publisher's push-notification service worker script
+api: "GET https://cds.thepublive.com/publisher/{publisher_id}/static/service-worker.js/"
+---
+
+Returns the service worker JavaScript file used to power web push notifications for the publisher's website, served from S3.
+
+<Warning>
+  This endpoint returns `404` if push notifications are not enabled for the publisher. Check `publisher_config → widget_config_json → push_notification_config` to determine availability before serving this file.
+</Warning>
+
+<ParamField path="publisher_id" type="string" required>
+  Your Publisher ID
+</ParamField>
+
+<ResponseExample>
+
+```json 200
+{
+  "status": "ok",
+  "data": {
+    "content": "self.addEventListener('push', function(event) { ... });"
+  }
+}
+```
+
+```json 401
+{
+  "detail": "Invalid Auth Credentials"
+}
+```
+
+```json 404
+{
+  "detail": "Push notifications are not enabled for this publisher"
+}
+```
+
+</ResponseExample>

--- a/docs.json
+++ b/docs.json
@@ -206,6 +206,26 @@
                 "pages": [
                   "api-reference/content-delivery/form-schema"
                 ]
+              },
+              {
+                "group": "Static Files",
+                "pages": [
+                  "api-reference/content-delivery/static-ads-txt",
+                  "api-reference/content-delivery/static-robots-txt",
+                  "api-reference/content-delivery/static-service-worker",
+                  "api-reference/content-delivery/static-push-notification-html"
+                ]
+              },
+              {
+                "group": "Sitemaps",
+                "pages": [
+                  "api-reference/content-delivery/sitemap-allcontent",
+                  "api-reference/content-delivery/sitemap-webcontent",
+                  "api-reference/content-delivery/sitemap-news",
+                  "api-reference/content-delivery/sitemap-category",
+                  "api-reference/content-delivery/sitemap-webstory",
+                  "api-reference/content-delivery/sitemap-paginated"
+                ]
               }
             ]
           },


### PR DESCRIPTION
… API

- Introduced new endpoints for static files including ads.txt, robots.txt, service-worker.js, and push notification HTML files.
- Added detailed documentation for various sitemaps: All-content, Web Content, News, Category, Web Story, and Paginated Sitemaps.
- Enhanced the README with a new section for static files and sitemaps, providing descriptions and usage examples.