### PR TITLE
docs(sprint-37): add AI Copilot page, document API user exclusion fro…

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -69,7 +69,8 @@
               "documentation/getting-started/core-concepts",
               "documentation/concepts-features/custom-entities",
               "documentation/concepts-features/forms",
-              "documentation/concepts-features/media-library"
+              "documentation/concepts-features/media-library",
+              "documentation/concepts-features/ai-copilot"
             ]
           },
           {

--- a/documentation/concepts-features/ai-copilot.mdx
+++ b/documentation/concepts-features/ai-copilot.mdx
@@ -1,8 +1,24 @@
 ---
 title: "AI Copilot"
-description: "AI-powered writing and editing assistance built into Publive"
+description: "AI-powered writing assistance built into the Publive editor — optimise titles, summaries, and meta descriptions without leaving your workflow."
 ---
 
-<Info>
-  **Coming soon** — Detailed documentation for AI Copilot is currently being prepared and will be available shortly.
-</Info>
+The AI Copilot gives editors inline AI suggestions directly inside the article editor. It surfaces at the right moment so it stays out of your way until you actually need it.
+
+## AI icon
+
+The AI sparkle icon (✦) appears inside the **Title**, **Summary**, and **Meta Description** fields when a field is focused or already contains a value. It stays hidden on empty, unfocused fields to keep the form uncluttered. The icon does not appear on read-only fields such as the Permalink.
+
+Click the icon to open the AI menu for that field.
+
+## Nudge tooltip
+
+When you paste text into the **Title**, **Summary**, or **Meta Description** field, a small tooltip appears below the field prompting you to optimise the content with AI. The tooltip dismisses automatically after a few seconds — no action needed. It will not reappear on the same field for the rest of your editing session.
+
+## First-visit announcement card
+
+The first time you open a page with AI features, a card appears in the bottom-right corner introducing the AI menu. Dismiss it by clicking the **✕** button in the card's top-right corner. The card will not appear again once dismissed.
+
+## NEW badge
+
+AI features that are newly introduced display a **NEW** badge on their icon. The badge disappears after you interact with that feature for the first time.

--- a/documentation/getting-started/authentication.mdx
+++ b/documentation/getting-started/authentication.mdx
@@ -81,6 +81,10 @@ Common causes:
 * Use the CDS API (read-only) for public-facing applications and reserve CMS API access for server-side operations
 </Warning>
 
+## API users and team membership
+
+API users are members with access to the **API Developer Hub**. They do **not** appear in the team member listing under **Settings → Team** and cannot be selected in contributor fields or any other member selector across the dashboard.
+
 ## Publisher ID
 
 Every API endpoint requires your `<PUBLISHER_ID>` in the URL path:

--- a/documentation/getting-started/mfa.mdx
+++ b/documentation/getting-started/mfa.mdx
@@ -27,3 +27,20 @@ Enabling MFA — whether for an individual or globally — immediately signs out
 | Lockout duration | 15 minutes |
 
 After 5 incorrect OTP attempts the account is locked for 15 minutes before another attempt can be made.
+
+## Admin password override
+
+Publishers Admins, Super Admins, and any custom role with the **Manage Members** permission can set a new password for any team member directly from the dashboard — without needing the member's current password.
+
+**Where to find it:** Go to **Team Members → Edit** for the relevant member. Scroll to the **Security** section and click **Manage Password** to expand the form.
+
+**How it works:**
+
+1. Enter the new password and confirm it.
+2. A confirmation dialog shows the member's name and what will happen — click **Confirm** to proceed.
+3. On success, the member receives an email notifying them their password was changed by an admin.
+4. The member's existing sessions remain active, but they must use the new password on their next login.
+
+<Note>
+The Security section is only visible to members who have the Manage Members permission. It is not rendered for other roles.
+</Note>


### PR DESCRIPTION
…m member listing, and admin password override

- New ai-copilot.mdx covers AI Suite v2 discoverability: sparkle icon conditional visibility, nudge tooltip after paste, first-visit announcement card, and NEW badge behaviour
- Added ai-copilot to Core Concepts nav in docs.json
- authentication.mdx: clarifies that API users are excluded from the team member listing and contributor selectors
- mfa.mdx: documents admin password override — who can use it, where to find it in the dashboard, and what happens after a reset